### PR TITLE
Updated README.md to match module version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![GitHub License](https://img.shields.io/github/license/btcpayserver/prestashop-plugin?color=brightgreen&style=flat-square)](https://github.com/btcpayserver/prestashop-plugin/blob/master/LICENSE)
 [![GitHub contributors](https://img.shields.io/github/contributors-anon/btcpayserver/prestashop-plugin?style=flat-square)](https://github.com/btcpayserver/prestashop-plugin/graphs/contributors)
 
-[![PrestaShop module version](https://img.shields.io/badge/module%20version-4.0.0-brightgreen?style=flat-square)](https://github.com/btcpayserver/prestashop-plugin/releases)
+[![PrestaShop module version](https://img.shields.io/badge/module%20version-4.0.1-brightgreen?style=flat-square)](https://github.com/btcpayserver/prestashop-plugin/releases)
 [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/btcpayserver/prestashop-plugin?sort=semver&style=flat-square)](https://github.com/btcpayserver/prestashop-plugin/releases)
 [![GitHub all releases](https://img.shields.io/github/downloads/btcpayserver/prestashop-plugin/total?style=flat-square)](https://github.com/btcpayserver/prestashop-plugin/releases)
 


### PR DESCRIPTION
Updated README.md to match the module version defined in [`btcpay.php`](https://github.com/btcpayserver/prestashop-plugin/blob/master/modules/btcpay/btcpay.php#L43).