### PR TITLE
Only run the validation workflow for pull requests

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,13 +1,13 @@
 name: "Validate"
 
-on: [ "push", "pull_request" ]
+on: [ "pull_request" ]
 
 jobs:
   linting:
     name: "Linting (PHP ${{ matrix.php-versions }})"
     runs-on: "ubuntu-latest"
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         php-versions: [ '7.3', '7.4', '8.0' ]
     steps:


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | There is no need to run the workflows for pushes, since you can only merge to 4.x/5.x via pull requests. Running them for all branches and all pushes is a waste of time (as you can run them locally yourself as well).
| Type?         | improvement
| BC breaks?    | no
| Deprecations? |  no
| Fixed ticket? | -
| How to test?  | -