### PR TITLE
Only remove the configuration during reset/uninstall

### DIFF
--- a/modules/btcpay/config.xml
+++ b/modules/btcpay/config.xml
@@ -2,10 +2,11 @@
 <module>
   <name>btcpay</name>
   <displayName><![CDATA[BTCPay]]></displayName>
-  <version><![CDATA[5.1.2]]></version>
+  <version><![CDATA[5.1.3]]></version>
   <description><![CDATA[Accept crypto payments via BTCPay Server.]]></description>
   <author><![CDATA[BTCPayServer]]></author>
   <tab><![CDATA[payments_gateways]]></tab>
+  <confirmUninstall><![CDATA[Are you sure that you want to uninstall this module? Past purchases and order states will be kept, but your configuration will be removed.]]></confirmUninstall>
   <is_configurable>1</is_configurable>
   <need_instance>1</need_instance>
   <limited_countries/>


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  |Only remove the configuration and don't touch any other data. This way everything will work if someone re-installs the module at a later point.
| Type?         | improvement 
| BC breaks?    | no
| Deprecations? | no
