### PR TITLE
Resolve "Create prestashop order after invoice paid"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BUILD_FOLDER := "./build"
 ZIP_NAME := "${MODULE}.zip"
 MODULE_OUT := "${BUILD_FOLDER}/${ZIP_NAME}"
 
-.PHONY: all build install clean lint lint-fix
+.PHONY: all build install upgrade clean lint lint-fix
 
 all: build
 
@@ -43,7 +43,7 @@ install: ## Install everything for development
 	@cd "$(MODULE_FOLDER)/$(MODULE)" \
 		&& composer install
 
-upgrade: ## Upgrade all depedencies (including development)
+upgrade: ## Upgrade all dependencies (including development)
 	# Upgrading all root dependencies
 	composer upgrade
 

--- a/modules/btcpay/btcpay.php
+++ b/modules/btcpay/btcpay.php
@@ -55,7 +55,7 @@ class BTCPay extends PaymentModule
 	{
 		$this->name                   = 'btcpay';
 		$this->tab                    = 'payments_gateways';
-		$this->version                = '5.1.3';
+		$this->version                = '5.1.4';
 		$this->author                 = 'BTCPay Server';
 		$this->ps_versions_compliancy = ['min' => Constants::MINIMUM_PS_VERSION, 'max' => _PS_VERSION_];
 		$this->controllers            = ['webhook', 'payment', 'validation'];
@@ -254,7 +254,7 @@ class BTCPay extends PaymentModule
 			return $this->display(__FILE__, 'views/templates/admin/invoice_block.tpl');
 		} catch (RequestException $exception) {
 			// Log the exception
-			PrestaShopLogger::addLog(\sprintf('[WARNING] Tried to load BTCPay invoice in hookDisplayAdminOrderMainBottom: %s', $exception->getMessage()), 2, $exception->getCode(), 'Order', $bitcoinPayment->getOrderId());
+			PrestaShopLogger::addLog(\sprintf('[WARNING] Tried to load BTCPay invoice in hookDisplayAdminOrderMainBottom: %s', $exception->getMessage()), \PrestaShopLogger::LOG_SEVERITY_LEVEL_WARNING, $exception->getCode(), 'Order', $bitcoinPayment->getOrderId());
 
 			// Show that the invoice was not found
 			return $this->display(__FILE__, 'views/templates/admin/invoice_missing_block.tpl');
@@ -324,7 +324,7 @@ class BTCPay extends PaymentModule
 			return $this->display(__FILE__, 'views/templates/hooks/order_detail.tpl');
 		} catch (RequestException $exception) {
 			// Log the exception
-			PrestaShopLogger::addLog(\sprintf('[WARNING] Tried to load BTCPay invoice in hookDisplayOrderDetail: %s', $exception->getMessage()), 2, $exception->getCode(), 'Order', $order->id);
+			PrestaShopLogger::addLog(\sprintf('[WARNING] Tried to load BTCPay invoice in hookDisplayOrderDetail: %s', $exception->getMessage()), \PrestaShopLogger::LOG_SEVERITY_LEVEL_WARNING, $exception->getCode(), 'Order', $order->id);
 
 			// If the invoice is gone just return null
 			return null;
@@ -451,12 +451,12 @@ class BTCPay extends PaymentModule
 			return;
 		}
 
-		PrestaShopLogger::addLog('[WARNING] Order has changed for cart: ' . $cart->id . '. Cancelling....', 2);
+		PrestaShopLogger::addLog('[INFO] Order has changed for cart. Cancelling....', \PrestaShopLogger::LOG_SEVERITY_LEVEL_WARNING, null, 'Cart', $cart->id);
 
 		// Try to remove the order
 		if (false === $bitcoinPayment->delete()) {
-			$error = \sprintf('[ERROR] Expected to remove the order %s, but failed to do so', $bitcoinPayment->order_id);
-			PrestaShopLogger::addLog($error, 3);
+			$error = \sprintf('[ERROR] Expected to remove the order %s, but failed to do so', $bitcoinPayment->getOrderId());
+			PrestaShopLogger::addLog($error, \PrestaShopLogger::LOG_SEVERITY_LEVEL_ERROR, null, 'BitcoinPayment', $bitcoinPayment->getId());
 
 			throw new \PrestaShopDatabaseException($error);
 		}

--- a/modules/btcpay/composer.json
+++ b/modules/btcpay/composer.json
@@ -24,7 +24,7 @@
     "ext-intl": "*",
     "ext-json": "*",
     "ext-mbstring": "*",
-    "btcpayserver/btcpayserver-greenfield-php": "^1.2",
+    "btcpayserver/btcpayserver-greenfield-php": "^1.3.2",
     "stechstudio/backoff": "^1.2"
   },
   "require-dev": {

--- a/modules/btcpay/composer.lock
+++ b/modules/btcpay/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "35f4c51f0db6994fd37c3d2abbef3984",
+    "content-hash": "160ded0efb82ad7c992e03f5d38cfdc4",
     "packages": [
         {
             "name": "btcpayserver/btcpayserver-greenfield-php",
-            "version": "v1.3.1",
+            "version": "v1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/btcpayserver/btcpayserver-greenfield-php.git",
-                "reference": "f6fa7aeea1dac2d7aa8e84f793cb98068d729fb4"
+                "reference": "563c1b94fb432d16719aad985c141d7e8ce13fbd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/btcpayserver/btcpayserver-greenfield-php/zipball/f6fa7aeea1dac2d7aa8e84f793cb98068d729fb4",
-                "reference": "f6fa7aeea1dac2d7aa8e84f793cb98068d729fb4",
+                "url": "https://api.github.com/repos/btcpayserver/btcpayserver-greenfield-php/zipball/563c1b94fb432d16719aad985c141d7e8ce13fbd",
+                "reference": "563c1b94fb432d16719aad985c141d7e8ce13fbd",
                 "shasum": ""
             },
             "require": {
@@ -55,9 +55,9 @@
             "description": "BTCPay Server Greenfield API PHP client library.",
             "support": {
                 "issues": "https://github.com/btcpayserver/btcpayserver-greenfield-php/issues",
-                "source": "https://github.com/btcpayserver/btcpayserver-greenfield-php/tree/v1.3.1"
+                "source": "https://github.com/btcpayserver/btcpayserver-greenfield-php/tree/v1.3.2"
             },
-            "time": "2022-02-14T20:30:46+00:00"
+            "time": "2022-03-16T21:27:27+00:00"
         },
         {
             "name": "stechstudio/backoff",
@@ -78,12 +78,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "STS\\Backoff\\": "src"
-                },
                 "files": [
                     "src/helpers.php"
-                ]
+                ],
+                "psr-4": {
+                    "STS\\Backoff\\": "src"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -554,25 +554,28 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "a74c203357d9b250a4019bc18e9a23a050e16bef"
+                "reference": "86b842d48cdaaab1bf3dc24fdc830bf7b58cfcab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/a74c203357d9b250a4019bc18e9a23a050e16bef",
-                "reference": "a74c203357d9b250a4019bc18e9a23a050e16bef",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/86b842d48cdaaab1bf3dc24fdc830bf7b58cfcab",
+                "reference": "86b842d48cdaaab1bf3dc24fdc830bf7b58cfcab",
                 "shasum": ""
             },
             "conflict": {
                 "3f/pygmentize": "<1.2",
                 "adodb/adodb-php": "<=5.20.20|>=5.21,<=5.21.3",
                 "akaunting/akaunting": "<2.1.13",
+                "alextselegidis/easyappointments": "<1.4.3",
                 "alterphp/easyadmin-extension-bundle": ">=1.2,<1.2.11|>=1.3,<1.3.1",
                 "amazing/media2click": ">=1,<1.3.3",
                 "amphp/artax": "<1.0.6|>=2,<2.0.6",
                 "amphp/http": "<1.0.1",
                 "amphp/http-client": ">=4,<4.4",
                 "anchorcms/anchor-cms": "<=0.12.7",
+                "andreapollastri/cipi": "<=3.1.15",
                 "api-platform/core": ">=2.2,<2.2.10|>=2.3,<2.3.6",
+                "appwrite/server-ce": "<0.11.1|>=0.12,<0.12.2",
                 "area17/twill": "<1.2.5|>=2,<2.5.3",
                 "asymmetricrypt/asymmetricrypt": ">=0,<9.9.99",
                 "aws/aws-sdk-php": ">=3,<3.2.1",
@@ -599,10 +602,10 @@
                 "cesnet/simplesamlphp-module-proxystatistics": "<3.1",
                 "codeception/codeception": "<3.1.3|>=4,<4.1.22",
                 "codeigniter/framework": "<=3.0.6",
-                "codeigniter4/framework": "<4.1.8",
+                "codeigniter4/framework": "<4.1.9",
                 "codiad/codiad": "<=2.8.4",
                 "composer/composer": "<1.10.23|>=2-alpha.1,<2.1.9",
-                "concrete5/concrete5": "<8.5.5",
+                "concrete5/concrete5": "<9",
                 "concrete5/core": "<8.5.7",
                 "contao-components/mediaelement": ">=2.14.2,<2.21.1",
                 "contao/core": ">=2,<3.5.39",
@@ -623,15 +626,16 @@
                 "doctrine/mongodb-odm": ">=1,<1.0.2",
                 "doctrine/mongodb-odm-bundle": ">=2,<3.0.1",
                 "doctrine/orm": ">=2,<2.4.8|>=2.5,<2.5.1|>=2.8.3,<2.8.4",
-                "dolibarr/dolibarr": "<=14.0.5|>= 3.3.beta1, < 13.0.2",
+                "dolibarr/dolibarr": "<16|>= 3.3.beta1, < 13.0.2",
                 "dompdf/dompdf": ">=0.6,<0.6.2",
-                "drupal/core": ">=7,<7.80|>=8,<8.9.16|>=9,<9.1.12|>=9.2,<9.2.4",
+                "drupal/core": ">=7,<7.88|>=8,<9.2.13|>=9.3,<9.3.6",
                 "drupal/drupal": ">=7,<7.80|>=8,<8.9.16|>=9,<9.1.12|>=9.2,<9.2.4",
                 "dweeves/magmi": "<=0.7.24",
                 "ecodev/newsletter": "<=4",
+                "ectouch/ectouch": "<=2.7.2",
                 "elgg/elgg": "<3.3.24|>=4,<4.0.5",
                 "endroid/qr-code-bundle": "<3.4.2",
-                "enshrined/svg-sanitize": "<0.13.1",
+                "enshrined/svg-sanitize": "<0.15",
                 "erusev/parsedown": "<1.7.2",
                 "ether/logs": "<3.0.4",
                 "ezsystems/demobundle": ">=5.4,<5.4.6.1",
@@ -641,7 +645,7 @@
                 "ezsystems/ezplatform": "<=1.13.6|>=2,<=2.5.24",
                 "ezsystems/ezplatform-admin-ui": ">=1.3,<1.3.5|>=1.4,<1.4.6|>=1.5,<=1.5.25",
                 "ezsystems/ezplatform-admin-ui-assets": ">=4,<4.2.1|>=5,<5.0.1|>=5.1,<5.1.1",
-                "ezsystems/ezplatform-kernel": "<=1.2.5|>=1.3,<=1.3.1",
+                "ezsystems/ezplatform-kernel": "<=1.2.5|>=1.3,<1.3.12",
                 "ezsystems/ezplatform-rest": ">=1.2,<=1.2.2|>=1.3,<1.3.8",
                 "ezsystems/ezplatform-richtext": ">=2.3,<=2.3.7",
                 "ezsystems/ezplatform-user": ">=1,<1.0.1",
@@ -669,7 +673,8 @@
                 "froala/wysiwyg-editor": "<3.2.7",
                 "fuel/core": "<1.8.1",
                 "gaoming13/wechat-php-sdk": "<=1.10.2",
-                "getgrav/grav": "<1.7.28",
+                "genix/cms": "<=1.1.11",
+                "getgrav/grav": "<1.7.31",
                 "getkirby/cms": "<3.5.8",
                 "getkirby/panel": "<2.5.14",
                 "gilacms/gila": "<=1.11.4",
@@ -709,6 +714,7 @@
                 "la-haute-societe/tcpdf": "<6.2.22",
                 "laminas/laminas-form": "<2.17.1|>=3,<3.0.2|>=3.1,<3.1.1",
                 "laminas/laminas-http": "<2.14.2",
+                "laravel/fortify": "<1.11.1",
                 "laravel/framework": "<6.20.42|>=7,<7.30.6|>=8,<8.75",
                 "laravel/socialite": ">=1,<1.0.99|>=2,<2.0.10",
                 "latte/latte": "<2.10.8",
@@ -717,7 +723,7 @@
                 "league/commonmark": "<0.18.3",
                 "league/flysystem": "<1.1.4|>=2,<2.1.1",
                 "lexik/jwt-authentication-bundle": "<2.10.7|>=2.11,<2.11.3",
-                "librenms/librenms": "<=21.11",
+                "librenms/librenms": "<22.2.2",
                 "limesurvey/limesurvey": "<3.27.19",
                 "livehelperchat/livehelperchat": "<=3.91",
                 "livewire/livewire": ">2.2.4,<2.2.6",
@@ -728,12 +734,13 @@
                 "magento/magento1ee": ">=1,<1.14.4.3",
                 "magento/product-community-edition": ">=2,<2.2.10|>=2.3,<2.3.2-p.2",
                 "marcwillmann/turn": "<0.3.3",
-                "mautic/core": "<4|= 2.13.1",
+                "matyhtf/framework": "<=3.0.5",
+                "mautic/core": "<4.2|= 2.13.1",
                 "mediawiki/core": ">=1.27,<1.27.6|>=1.29,<1.29.3|>=1.30,<1.30.2|>=1.31,<1.31.9|>=1.32,<1.32.6|>=1.32.99,<1.33.3|>=1.33.99,<1.34.3|>=1.34.99,<1.35",
-                "microweber/microweber": "<1.2.11",
+                "microweber/microweber": "<1.3",
                 "miniorange/miniorange-saml": "<1.4.3",
                 "mittwald/typo3_forum": "<1.2.1",
-                "modx/revolution": "<2.8",
+                "modx/revolution": "<= 2.8.3-pl|<2.8",
                 "monolog/monolog": ">=1.8,<1.12",
                 "moodle/moodle": "<3.9.11|>=3.10-beta,<3.10.8|>=3.11,<3.11.5",
                 "mustache/mustache": ">=2,<2.14.1",
@@ -754,7 +761,7 @@
                 "october/cms": "= 1.1.1|= 1.0.471|= 1.0.469|>=1.0.319,<1.0.469",
                 "october/october": ">=1.0.319,<1.0.466|>=2.1,<2.1.12",
                 "october/rain": "<1.0.472|>=1.1,<1.1.2",
-                "october/system": "<1.0.473|>=1.1,<1.1.6|>=2.1,<2.1.12",
+                "october/system": "<1.0.475|>=1.1,<1.1.11|>=2,<2.1.27",
                 "onelogin/php-saml": "<2.10.4",
                 "oneup/uploader-bundle": "<1.9.3|>=2,<2.1.5",
                 "opencart/opencart": "<=3.0.3.2",
@@ -770,6 +777,7 @@
                 "passbolt/passbolt_api": "<2.11",
                 "paypal/merchant-sdk-php": "<3.12",
                 "pear/archive_tar": "<1.4.14",
+                "pear/crypt_gpg": "<1.6.7",
                 "pegasus/google-for-jobs": "<1.5.1|>=2,<2.1.1",
                 "personnummer/personnummer": "<3.0.2",
                 "phanan/koel": "<5.1.4",
@@ -784,7 +792,7 @@
                 "phpunit/phpunit": ">=4.8.19,<4.8.28|>=5.0.10,<5.6.3",
                 "phpwhois/phpwhois": "<=4.2.5",
                 "phpxmlrpc/extras": "<0.6.1",
-                "pimcore/pimcore": "<=10.3",
+                "pimcore/pimcore": "<=10.3.2",
                 "pocketmine/pocketmine-mp": "<4.0.7",
                 "pressbooks/pressbooks": "<5.18",
                 "prestashop/autoupgrade": ">=4,<4.10.1",
@@ -806,15 +814,18 @@
                 "remdex/livehelperchat": "<3.93",
                 "rmccue/requests": ">=1.6,<1.8",
                 "robrichards/xmlseclibs": "<3.0.4",
+                "rudloff/alltube": "<3.0.3",
+                "s-cart/s-cart": "<6.7.2",
                 "sabberworm/php-css-parser": ">=1,<1.0.1|>=2,<2.0.1|>=3,<3.0.1|>=4,<4.0.1|>=5,<5.0.9|>=5.1,<5.1.3|>=5.2,<5.2.1|>=6,<6.0.2|>=7,<7.0.4|>=8,<8.0.1|>=8.1,<8.1.1|>=8.2,<8.2.1|>=8.3,<8.3.1",
                 "sabre/dav": ">=1.6,<1.6.99|>=1.7,<1.7.11|>=1.8,<1.8.9",
                 "scheb/two-factor-bundle": ">=0,<3.26|>=4,<4.11",
                 "sensiolabs/connect": "<4.2.3",
                 "serluck/phpwhois": "<=4.2.6",
-                "shopware/core": "<=6.4.6",
-                "shopware/platform": "<=6.4.6",
+                "shopware/core": "<=6.4.8.1",
+                "shopware/platform": "<=6.4.8.1",
                 "shopware/production": "<=6.3.5.2",
                 "shopware/shopware": "<5.7.7",
+                "shopware/storefront": "<=6.4.8.1",
                 "showdoc/showdoc": "<=2.10.2",
                 "silverstripe/admin": ">=1,<1.8.1",
                 "silverstripe/assets": ">=1,<1.4.7|>=1.5,<1.5.2",
@@ -822,7 +833,7 @@
                 "silverstripe/comments": ">=1.3,<1.9.99|>=2,<2.9.99|>=3,<3.1.1",
                 "silverstripe/forum": "<=0.6.1|>=0.7,<=0.7.3",
                 "silverstripe/framework": "<4.10.1",
-                "silverstripe/graphql": "<3.5.2|>=4-alpha.1,<4-alpha.2",
+                "silverstripe/graphql": "<3.5.2|>=4-alpha.1,<4-alpha.2|= 4.0.0-alpha1",
                 "silverstripe/registry": ">=2.1,<2.1.2|>=2.2,<2.2.1",
                 "silverstripe/restfulserver": ">=1,<1.0.9|>=2,<2.0.4",
                 "silverstripe/subsites": ">=2,<2.1.1",
@@ -835,13 +846,13 @@
                 "simplito/elliptic-php": "<1.0.6",
                 "slim/slim": "<2.6",
                 "smarty/smarty": "<3.1.43|>=4,<4.0.3",
-                "snipe/snipe-it": "<=5.3.7",
+                "snipe/snipe-it": "<5.3.11",
                 "socalnick/scn-social-auth": "<1.15.2",
                 "socialiteproviders/steam": "<1.1",
                 "spipu/html2pdf": "<5.2.4",
                 "spoonity/tcpdf": "<6.2.22",
                 "squizlabs/php_codesniffer": ">=1,<2.8.1|>=3,<3.0.1",
-                "ssddanbrown/bookstack": "<21.12.1",
+                "ssddanbrown/bookstack": "<22.2.3",
                 "stormpath/sdk": ">=0,<9.9.99",
                 "studio-42/elfinder": "<2.1.59",
                 "subrion/cms": "<=4.2.1",
@@ -877,7 +888,7 @@
                 "symfony/security-core": ">=2.4,<2.6.13|>=2.7,<2.7.9|>=2.7.30,<2.7.32|>=2.8,<3.4.49|>=4,<4.4.24|>=5,<5.2.9",
                 "symfony/security-csrf": ">=2.4,<2.7.48|>=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
                 "symfony/security-guard": ">=2.8,<3.4.48|>=4,<4.4.23|>=5,<5.2.8",
-                "symfony/security-http": ">=2.3,<2.3.41|>=2.4,<2.7.51|>=2.8,<3.4.48|>=4,<4.4.23|>=5,<5.2.8|>=5.3,<5.3.2",
+                "symfony/security-http": ">=2.3,<2.3.41|>=2.4,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.2.12|>=4.3,<4.3.8|>=4.4,<4.4.7|>=5,<5.0.7|>=5.1,<5.2.8|>=5.3,<5.3.2",
                 "symfony/serializer": ">=2,<2.0.11|>=4.1,<4.4.35|>=5,<5.3.12",
                 "symfony/symfony": ">=2,<3.4.49|>=4,<4.4.35|>=5,<5.3.12|>=5.3.14,<=5.3.14|>=5.4.3,<=5.4.3|>=6.0.3,<=6.0.3",
                 "symfony/translation": ">=2,<2.0.17",
@@ -897,9 +908,9 @@
                 "topthink/framework": "<6.0.9",
                 "topthink/think": "<=6.0.9",
                 "topthink/thinkphp": "<=3.2.3",
-                "tribalsystems/zenario": "<8.8.53370",
+                "tribalsystems/zenario": "<9.2.55826",
                 "truckersmp/phpwhois": "<=4.3.1",
-                "twig/twig": "<1.38|>=2,<2.14.11|>3,<3.3.8",
+                "twig/twig": "<1.38|>=2,<2.14.11|>=3,<3.3.8",
                 "typo3/cms": ">=6.2,<6.2.30|>=7,<7.6.32|>=8,<8.7.38|>=9,<9.5.29|>=10,<10.4.19|>=11,<11.5",
                 "typo3/cms-backend": ">=7,<=7.6.50|>=8,<=8.7.39|>=9,<=9.5.24|>=10,<=10.4.13|>=11,<=11.1",
                 "typo3/cms-core": ">=6.2,<=6.2.56|>=7,<=7.6.52|>=8,<=8.7.41|>=9,<9.5.29|>=10,<10.4.19|>=11,<11.5",
@@ -997,7 +1008,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-02-11T21:12:37+00:00"
+            "time": "2022-03-14T19:04:00+00:00"
         },
         {
             "name": "symfony/debug-bundle",
@@ -1382,16 +1393,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v5.4.3",
+            "version": "v5.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "ef409ff341a565a3663157d4324536746d49a0c7"
+                "reference": "34e89bc147633c0f9dd6caaaf56da3b806a21465"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/ef409ff341a565a3663157d4324536746d49a0c7",
-                "reference": "ef409ff341a565a3663157d4324536746d49a0c7",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/34e89bc147633c0f9dd6caaaf56da3b806a21465",
+                "reference": "34e89bc147633c0f9dd6caaaf56da3b806a21465",
                 "shasum": ""
             },
             "require": {
@@ -1435,7 +1446,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v5.4.3"
+                "source": "https://github.com/symfony/http-foundation/tree/v5.4.6"
             },
             "funding": [
                 {
@@ -1451,20 +1462,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:53:40+00:00"
+            "time": "2022-03-05T21:03:43+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v5.4.4",
+            "version": "v5.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "49f40347228c773688a0488feea0175aa7f4d268"
+                "reference": "d41f29ae9af1b5f40c7ebcddf09082953229411d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/49f40347228c773688a0488feea0175aa7f4d268",
-                "reference": "49f40347228c773688a0488feea0175aa7f4d268",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/d41f29ae9af1b5f40c7ebcddf09082953229411d",
+                "reference": "d41f29ae9af1b5f40c7ebcddf09082953229411d",
                 "shasum": ""
             },
             "require": {
@@ -1547,7 +1558,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v5.4.4"
+                "source": "https://github.com/symfony/http-kernel/tree/v5.4.6"
             },
             "funding": [
                 {
@@ -1563,11 +1574,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-29T18:08:07+00:00"
+            "time": "2022-03-05T21:14:51+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.24.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -1599,12 +1610,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1629,7 +1640,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.24.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.25.0"
             },
             "funding": [
                 {
@@ -1649,7 +1660,7 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.24.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
@@ -1712,7 +1723,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.24.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.25.0"
             },
             "funding": [
                 {
@@ -1732,16 +1743,16 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.24.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "57b712b08eddb97c762a8caa32c84e037892d2e9"
+                "reference": "4407588e0d3f1f52efb65fbe92babe41f37fe50c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/57b712b08eddb97c762a8caa32c84e037892d2e9",
-                "reference": "57b712b08eddb97c762a8caa32c84e037892d2e9",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/4407588e0d3f1f52efb65fbe92babe41f37fe50c",
+                "reference": "4407588e0d3f1f52efb65fbe92babe41f37fe50c",
                 "shasum": ""
             },
             "require": {
@@ -1795,7 +1806,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.24.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.25.0"
             },
             "funding": [
                 {
@@ -1811,7 +1822,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-13T13:58:33+00:00"
+            "time": "2022-03-04T08:16:47+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -1893,16 +1904,16 @@
         },
         {
             "name": "symfony/twig-bridge",
-            "version": "v5.4.3",
+            "version": "v5.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/twig-bridge.git",
-                "reference": "925719b20832e3dabd399fd9ebf85ed0eabf9999"
+                "reference": "648c8694a9470ae4aaf64cbce1b640f5941fd7c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/925719b20832e3dabd399fd9ebf85ed0eabf9999",
-                "reference": "925719b20832e3dabd399fd9ebf85ed0eabf9999",
+                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/648c8694a9470ae4aaf64cbce1b640f5941fd7c9",
+                "reference": "648c8694a9470ae4aaf64cbce1b640f5941fd7c9",
                 "shasum": ""
             },
             "require": {
@@ -1994,7 +2005,7 @@
             "description": "Provides integration for Twig with various Symfony components",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/twig-bridge/tree/v5.4.3"
+                "source": "https://github.com/symfony/twig-bridge/tree/v5.4.5"
             },
             "funding": [
                 {
@@ -2010,20 +2021,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:53:40+00:00"
+            "time": "2022-02-09T08:59:58+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v4.4.37",
+            "version": "v4.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "e74eee4ec02de71db3d60151aa5b203c990556df"
+                "reference": "35237c5e5dcb6593a46a860ba5b29c1d4683d80e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/e74eee4ec02de71db3d60151aa5b203c990556df",
-                "reference": "e74eee4ec02de71db3d60151aa5b203c990556df",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/35237c5e5dcb6593a46a860ba5b29c1d4683d80e",
+                "reference": "35237c5e5dcb6593a46a860ba5b29c1d4683d80e",
                 "shasum": ""
             },
             "require": {
@@ -2083,7 +2094,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v4.4.37"
+                "source": "https://github.com/symfony/var-dumper/tree/v4.4.39"
             },
             "funding": [
                 {
@@ -2099,7 +2110,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:41:36+00:00"
+            "time": "2022-02-25T10:38:15+00:00"
         },
         {
             "name": "twig/twig",

--- a/modules/btcpay/config.xml
+++ b/modules/btcpay/config.xml
@@ -2,7 +2,7 @@
 <module>
   <name>btcpay</name>
   <displayName><![CDATA[BTCPay]]></displayName>
-  <version><![CDATA[5.1.3]]></version>
+  <version><![CDATA[5.1.4]]></version>
   <description><![CDATA[Accept crypto payments via BTCPay Server.]]></description>
   <author><![CDATA[BTCPayServer]]></author>
   <tab><![CDATA[payments_gateways]]></tab>

--- a/modules/btcpay/controllers/front/webhook.php
+++ b/modules/btcpay/controllers/front/webhook.php
@@ -42,7 +42,7 @@ class BTCPayWebhookModuleFrontController extends \ModuleFrontController
 
 		$this->configuration = new Configuration();
 		$this->client        = Client::createFromConfiguration($this->configuration);
-		$this->handler       = new WebhookHandler($this->client, new LegacyBitcoinPaymentRepository());
+		$this->handler       = new WebhookHandler($this->module, $this->client, new LegacyBitcoinPaymentRepository());
 	}
 
 	/**

--- a/modules/btcpay/src/Constants.php
+++ b/modules/btcpay/src/Constants.php
@@ -35,6 +35,9 @@ class Constants
 	public const CONFIGURATION_DEFAULT_HOST = 'https://testnet.demo.btcpayserver.org';
 
 	// Order (creation) related configuration
+	public const CONFIGURATION_ORDER_MODE             = 'BTCPAY_ORDERMODE';
+
+	// Order states
 	public const CONFIGURATION_ORDER_STATE_WAITING    = 'BTCPAY_OS_WAITING';
 	public const CONFIGURATION_ORDER_STATE_CONFIRMING = 'BTCPAY_OS_CONFIRMING';
 	public const CONFIGURATION_ORDER_STATE_FAILED     = 'BTCPAY_OS_FAILED';
@@ -46,4 +49,9 @@ class Constants
 	// All possible transaction speeds as defined by BTCPay server
 	public const CONFIGURATION_SPEED_MODE = 'BTCPAY_TXSPEED';
 	public const TRANSACTION_SPEEDS       = [InvoiceCheckoutOptions::SPEED_HIGH, InvoiceCheckoutOptions::SPEED_MEDIUM, InvoiceCheckoutOptions::SPEED_LOW];
+
+	// All possible options for order creation (before or after payment)
+	public const ORDER_MODES       = [self::ORDER_MODE_BEFORE, self::ORDER_MODE_AFTER];
+	public const ORDER_MODE_BEFORE = 'before_payment';
+	public const ORDER_MODE_AFTER  = 'after_payment';
 }

--- a/modules/btcpay/src/Controller/Admin/Improve/Payment/ConfigureController.php
+++ b/modules/btcpay/src/Controller/Admin/Improve/Payment/ConfigureController.php
@@ -60,6 +60,7 @@ class ConfigureController extends FrameworkBundleAdminController
 			'form'          => $this->get('prestashop.module.btcpay.form_handler')->getForm()->createView(),
 			'help_link'     => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
 			'storeId'       => $this->configuration->get(Constants::CONFIGURATION_BTCPAY_STORE_ID),
+			'webhookId'     => $this->configuration->get(Constants::CONFIGURATION_BTCPAY_WEBHOOK_ID),
 			'client'        => Client::createFromConfiguration($this->configuration),
 			'moduleVersion' => $this->module->version,
 			'enableSidebar' => true,

--- a/modules/btcpay/src/Form/ConfigureFormDataProvider.php
+++ b/modules/btcpay/src/Form/ConfigureFormDataProvider.php
@@ -28,6 +28,7 @@ class ConfigureFormDataProvider implements FormDataProviderInterface
 		$configuration = new Configuration(
 			$this->configuration->get(Constants::CONFIGURATION_BTCPAY_HOST, Constants::CONFIGURATION_DEFAULT_HOST),
 			$this->configuration->get(Constants::CONFIGURATION_SPEED_MODE, InvoiceCheckoutOptions::SPEED_MEDIUM),
+			$this->configuration->get(Constants::CONFIGURATION_ORDER_MODE, Constants::ORDER_MODE_BEFORE),
 			$this->configuration->get(Constants::CONFIGURATION_SHARE_METADATA, false),
 		);
 
@@ -44,6 +45,7 @@ class ConfigureFormDataProvider implements FormDataProviderInterface
 
 		$this->configuration->set(Constants::CONFIGURATION_BTCPAY_HOST, \rtrim(\trim($configuration->getUrl()), '/\\'));
 		$this->configuration->set(Constants::CONFIGURATION_SPEED_MODE, $configuration->getSpeed());
+		$this->configuration->set(Constants::CONFIGURATION_ORDER_MODE, $configuration->getOrderMode());
 		$this->configuration->set(Constants::CONFIGURATION_SHARE_METADATA, $configuration->shareMetadata());
 
 		// All is fine

--- a/modules/btcpay/src/Form/Data/Configuration.php
+++ b/modules/btcpay/src/Form/Data/Configuration.php
@@ -23,14 +23,23 @@ class Configuration
 	private $speed;
 
 	/**
+	 * @Assert\NotBlank()
+	 * @Assert\Choice(choices=\BTCPay\Constants::ORDER_MODES, message="Invalid order mode")
+	 *
+	 * @var string
+	 */
+	private $orderMode;
+
+	/**
 	 * @Assert\Choice(choices={true, false})
 	 */
 	private $shareMetadata;
 
-	public function __construct(string $url, string $speed, bool $shareMetadata)
+	public function __construct(string $url, string $speed, string $orderMode, bool $shareMetadata)
 	{
 		$this->url           = $url;
 		$this->speed         = $speed;
+		$this->orderMode     = $orderMode;
 		$this->shareMetadata = $shareMetadata;
 	}
 
@@ -54,6 +63,16 @@ class Configuration
 		$this->speed = $speed;
 	}
 
+	public function getOrderMode(): string
+	{
+		return $this->orderMode;
+	}
+
+	public function setOrderMode(string $order_mode): void
+	{
+		$this->orderMode = $order_mode;
+	}
+
 	public function shareMetadata(): bool
 	{
 		return $this->shareMetadata;
@@ -69,6 +88,7 @@ class Configuration
 		return [
 			'url'           => $this->url,
 			'speed'         => $this->speed,
+			'orderMode'     => $this->orderMode,
 			'shareMetadata' => $this->shareMetadata,
 		];
 	}

--- a/modules/btcpay/src/Form/Type/ConfigureType.php
+++ b/modules/btcpay/src/Form/Type/ConfigureType.php
@@ -2,6 +2,7 @@
 
 namespace BTCPay\Form\Type;
 
+use BTCPay\Constants;
 use BTCPay\Form\Data\Configuration;
 use BTCPayServer\Client\InvoiceCheckoutOptions;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
@@ -28,12 +29,19 @@ class ConfigureType extends TranslatorAwareType
 				'label'      => $this->trans('Transaction speed', 'Modules.Btcpay.Admin'),
 				'empty_data' => InvoiceCheckoutOptions::SPEED_MEDIUM,
 			])
+			->add('order_mode', ChoiceType::class, [
+				'choices' => [
+					$this->trans('Order before payment', 'Modules.Btcpay.Admin') => Constants::ORDER_MODE_BEFORE,
+					$this->trans('Order after payment', 'Modules.Btcpay.Admin')  => Constants::ORDER_MODE_AFTER,
+				],
+				'label'   => $this->trans('Order creation method', 'Modules.Btcpay.Admin'),
+			])
 			->add('share_metadata', ChoiceType::class, [
 				'choices' => [
 					$this->trans('Yes', 'Modules.Btcpay.Admin') => true,
 					$this->trans('No', 'Modules.Btcpay.Admin')  => false,
 				],
-				'label'   => $this->trans('Set customer data in BTCPay Server invoice', 'Modules.Btcpay.Admin'),
+				'label'   => $this->trans('Store customer data in BTCPay Server invoice', 'Modules.Btcpay.Admin'),
 			]);
 	}
 

--- a/modules/btcpay/src/Installer/Config.php
+++ b/modules/btcpay/src/Installer/Config.php
@@ -26,6 +26,7 @@ class Config
 		// Init clear configurations
 		if (!$this->configuration->set(Constants::CONFIGURATION_BTCPAY_HOST, Constants::CONFIGURATION_DEFAULT_HOST)
 			|| !$this->configuration->set(Constants::CONFIGURATION_SPEED_MODE, InvoiceCheckoutOptions::SPEED_MEDIUM)
+			|| !$this->configuration->set(Constants::CONFIGURATION_ORDER_MODE, Constants::ORDER_MODE_BEFORE)
 			|| !$this->configuration->set(Constants::CONFIGURATION_BTCPAY_API_KEY, null)
 			|| !$this->configuration->set(Constants::CONFIGURATION_BTCPAY_STORE_ID, null)
 			|| !$this->configuration->set(Constants::CONFIGURATION_BTCPAY_WEBHOOK_ID, null)
@@ -51,6 +52,7 @@ class Config
 		// Remove configuration
 		if (!$this->configuration->remove(Constants::CONFIGURATION_BTCPAY_HOST)
 			|| !$this->configuration->remove(Constants::CONFIGURATION_SPEED_MODE)
+			|| !$this->configuration->remove(Constants::CONFIGURATION_ORDER_MODE)
 			|| !$this->configuration->remove(Constants::CONFIGURATION_BTCPAY_API_KEY)
 			|| !$this->configuration->remove(Constants::CONFIGURATION_BTCPAY_STORE_ID)
 			|| !$this->configuration->remove(Constants::CONFIGURATION_BTCPAY_WEBHOOK_ID)

--- a/modules/btcpay/src/Invoice/Processor.php
+++ b/modules/btcpay/src/Invoice/Processor.php
@@ -1,0 +1,290 @@
+<?php
+
+namespace BTCPay\Invoice;
+
+use BTCPay\Constants;
+use BTCPay\Entity\BitcoinPayment;
+use BTCPay\Server\Client;
+use PrestaShop\PrestaShop\Adapter\Configuration;
+
+class Processor
+{
+	/**
+	 * @var Configuration
+	 */
+	private $configuration;
+
+	/**
+	 * @var Client
+	 */
+	private $client;
+
+	/**
+	 * @var \BTCPay
+	 */
+	private $module;
+
+	public function __construct(\BTCPay $module, Configuration $configuration, Client $client)
+	{
+		$this->configuration = $configuration;
+		$this->client = $client;
+		$this->module = $module;
+	}
+
+	/**
+	 * @throws \JsonException
+	 * @throws \PrestaShopDatabaseException
+	 * @throws \PrestaShopException
+	 */
+	public function paymentConfirmed(BitcoinPayment $bitcoinPayment)
+	{
+		// Get the order
+		$order = new \Order($bitcoinPayment->getOrderId());
+
+		// Set the default status to be the current status
+		$orderStatus = $order->current_state;
+
+		// Get the store ID
+		$storeID = $this->configuration->get(Constants::CONFIGURATION_BTCPAY_STORE_ID);
+
+		// Grab the invoice from the server
+		$invoice = $this->client->invoice()->getInvoice($storeID, $bitcoinPayment->getInvoiceId());
+
+		// Change state if it's paid/processing
+		if ($invoice->isPaid() || $invoice->isProcessing()) {
+			// Transaction received but we have to wait some confirmation
+			$orderStatus = (string) $this->configuration->get(Constants::CONFIGURATION_ORDER_STATE_CONFIRMING);
+		}
+
+		// Change state if it's fully paid
+		if ($invoice->isFullyPaid()) {
+			// Transaction confirmed on the network
+			$orderStatus = (string) $this->configuration->get(Constants::CONFIGURATION_ORDER_STATE_PAID);
+		}
+
+		// Transaction was marked completed via BTCPay Server
+		if ($invoice->isMarked()) {
+			$orderStatus = (string) $this->configuration->get(Constants::CONFIGURATION_ORDER_STATE_PAID);
+		}
+
+		// Add a message if the user paid too late
+		if ($invoice->isPaidLate()) {
+			\PrestaShopLogger::addLog('[INFO] User paid after expiration for this invoice', \PrestaShopLogger::LOG_SEVERITY_LEVEL_INFORMATIVE, null, 'Order', $order->id);
+		}
+
+		// Add a message if the overpaid
+		if ($invoice->isOverpaid()) {
+			\PrestaShopLogger::addLog('[INFO] User overpaid for this order', \PrestaShopLogger::LOG_SEVERITY_LEVEL_INFORMATIVE, null, 'Order', $order->id);
+		}
+
+		// If nothing changed, return
+		if ((string) $order->current_state === $orderStatus) {
+			\PrestaShopLogger::addLog('[INFO] The state is the same as the one received', \PrestaShopLogger::LOG_SEVERITY_LEVEL_INFORMATIVE, null, 'Order', $order->id);
+
+			return;
+		}
+
+		// Set the status
+		$bitcoinPayment->setStatus((string) $orderStatus);
+
+		// Update the object
+		if (false === $bitcoinPayment->update(true)) {
+			$error = \sprintf('[ERROR] Could not update bitcoin_payment: %s', \Db::getInstance()->getMsgError());
+			\PrestaShopLogger::addLog($error, \PrestaShopLogger::LOG_SEVERITY_LEVEL_ERROR, null, 'BitcoinPayment', $bitcoinPayment->getId());
+
+			throw new \RuntimeException($error);
+		}
+
+		// Add the order change to the order history table
+		$orderHistory = new \OrderHistory();
+		$orderHistory->id_order = $bitcoinPayment->getOrderId();
+
+		// Store the change
+		$orderHistory->changeIdOrderState($orderStatus, $bitcoinPayment->getOrderId(), true);
+		$orderHistory->add(true);
+	}
+
+	/**
+	 * @throws \JsonException
+	 * @throws \PrestaShopDatabaseException
+	 * @throws \PrestaShopException
+	 */
+	public function paymentFailed(BitcoinPayment $bitcoinPayment)
+	{
+		// Get the order
+		$order = new \Order($bitcoinPayment->getOrderId());
+
+		// Set the default status to be the current status
+		$orderStatus = $order->current_state;
+
+		// Get the store ID
+		$storeID = $this->configuration->get(Constants::CONFIGURATION_BTCPAY_STORE_ID);
+
+		// Grab the invoice from the server
+		$invoice = $this->client->invoice()->getInvoice($storeID, $bitcoinPayment->getInvoiceId());
+
+		// Change the order status if needed
+		if ($invoice->isInvalid() || $invoice->isExpired()) {
+			// Expiration for the invoice has passed, so mark it failed
+			$orderStatus = (string) $this->configuration->get(Constants::CONFIGURATION_ORDER_STATE_FAILED);
+		}
+
+		// Transaction was marked completed via BTCPay Server
+		if ($invoice->isMarked()) {
+			$orderStatus = (string) $this->configuration->get(Constants::CONFIGURATION_ORDER_STATE_FAILED);
+		}
+
+		// If nothing changed, return
+		if ((string) $order->current_state === $orderStatus) {
+			\PrestaShopLogger::addLog('[INFO] The state is the same as the one received', \PrestaShopLogger::LOG_SEVERITY_LEVEL_INFORMATIVE, null, 'Order', $order->id);
+
+			return;
+		}
+
+		// Update the status
+		$bitcoinPayment->setStatus((string) $orderStatus);
+
+		// Update the object
+		if (false === $bitcoinPayment->update(true)) {
+			$error = \sprintf('[ERROR] Could not update bitcoin_payment: %s', \Db::getInstance()->getMsgError());
+			\PrestaShopLogger::addLog($error, \PrestaShopLogger::LOG_SEVERITY_LEVEL_ERROR, null, 'BitcoinPayment', $bitcoinPayment->getId());
+
+			throw new \RuntimeException($error);
+		}
+
+		// Add the order change to the order history table
+		$orderHistory = new \OrderHistory();
+		$orderHistory->id_order = $bitcoinPayment->getOrderId();
+
+		// Store the change
+		$orderHistory->changeIdOrderState($orderStatus, $bitcoinPayment->getOrderId(), true);
+		$orderHistory->add(true);
+	}
+
+	/**
+	 * @throws \JsonException
+	 * @throws \PrestaShopDatabaseException
+	 * @throws \PrestaShopException
+	 */
+	public function paymentReceived(BitcoinPayment $bitcoinPayment)
+	{
+		// Get the order
+		$order = new \Order($bitcoinPayment->getOrderId());
+
+		// Specify what status it will be
+		$orderStatus = (string) $this->configuration->get(Constants::CONFIGURATION_ORDER_STATE_CONFIRMING);
+
+		// If nothing changed, return
+		if ((string) $order->current_state === $orderStatus) {
+			\PrestaShopLogger::addLog('[INFO] The state is the same as the one received', \PrestaShopLogger::LOG_SEVERITY_LEVEL_INFORMATIVE, null, 'Order', $order->id);
+
+			return;
+		}
+
+		// Get the store ID
+		$storeID = $this->configuration->get(Constants::CONFIGURATION_BTCPAY_STORE_ID);
+
+		// Grab the invoice from the server
+		$invoice = $this->client->invoice()->getInvoice($storeID, $bitcoinPayment->getInvoiceId());
+
+		// Add a message if the user paid too late
+		if ($invoice->isPaidLate()) {
+			\PrestaShopLogger::addLog('[INFO] User paid after expiration for this invoice', \PrestaShopLogger::LOG_SEVERITY_LEVEL_INFORMATIVE, null, 'Order', $order->id);
+		}
+
+		// Add a message if the overpaid
+		if ($invoice->isOverpaid()) {
+			\PrestaShopLogger::addLog('[INFO] User overpaid for this order', \PrestaShopLogger::LOG_SEVERITY_LEVEL_INFORMATIVE, null, 'Order', $order->id);
+		}
+
+		// Update the status
+		$bitcoinPayment->setStatus($orderStatus);
+
+		// Update the object
+		if (false === $bitcoinPayment->update(true)) {
+			$error = \sprintf('[ERROR] Could not update bitcoin_payment: %s', \Db::getInstance()->getMsgError());
+			\PrestaShopLogger::addLog($error, \PrestaShopLogger::LOG_SEVERITY_LEVEL_ERROR, null, 'BitcoinPayment', $bitcoinPayment->getId());
+
+			throw new \RuntimeException($error);
+		}
+
+		// Add the order change to the order history table
+		$orderHistory = new \OrderHistory();
+		$orderHistory->id_order = $bitcoinPayment->getOrderId();
+
+		// Store the change
+		$orderHistory->changeIdOrderState($orderStatus, $bitcoinPayment->getOrderId(), true);
+		$orderHistory->add(true);
+	}
+
+	/**
+	 * @throws \JsonException
+	 * @throws \PrestaShopDatabaseException
+	 * @throws \PrestaShopException
+	 */
+	public function paymentReceivedCreateAfter(BitcoinPayment $bitcoinPayment)
+	{
+		// Specify what status it will be
+		$orderStatus = (string) $this->configuration->get(Constants::CONFIGURATION_ORDER_STATE_CONFIRMING);
+
+		// Get the store ID
+		$storeID = $this->configuration->get(Constants::CONFIGURATION_BTCPAY_STORE_ID);
+
+		// Grab the invoice from the server
+		$invoice = $this->client->invoice()->getInvoice($storeID, $bitcoinPayment->getInvoiceId());
+
+		// Fetch the secure key, which is used to check if the order has been made from this store
+		if (null === ($invoiceData = $invoice->getData()) || !\array_key_exists('metadata', $invoiceData) || !\array_key_exists('posData', $invoiceData['metadata'])) {
+			\PrestaShopLogger::addLog('[ERROR] Secure key was not defined', \PrestaShopLogger::LOG_SEVERITY_LEVEL_ERROR);
+
+			return;
+		}
+
+		// Grab the secure key
+		$secureKey = $invoiceData['metadata']['posData'];
+
+		// Generate an order only if there is not another one with this cart
+		if ($existingOrder = \Order::getByCartId($bitcoinPayment->getCartId())) {
+			$message = \sprintf('[INFO] Invoice %s already has an order %s', $bitcoinPayment->getInvoiceId(), $existingOrder->reference);
+			\PrestaShopLogger::addLog($message, \PrestaShopLogger::LOG_SEVERITY_LEVEL_INFORMATIVE, null, 'BitcoinPayment', $bitcoinPayment->getId());
+
+			return;
+		}
+
+		$this->module->validateOrder(
+			$bitcoinPayment->getCartId(),
+			$orderStatus,
+			$bitcoinPayment->getAmount(),
+			$this->module->displayName, // BTCPay
+			null, //message should be new Message
+			[], // extra variables for mail
+			null, //currency special
+			false, // don't touch amount
+			$secureKey
+		);
+
+		// Get the new order ID
+		$order = \Order::getByCartId($bitcoinPayment->getCartId());
+
+		$bitcoinPayment->setOrderId($order->id);
+		$bitcoinPayment->setStatus($orderStatus);
+
+		// Add a message if the user paid too late
+		if ($invoice->isPaidLate()) {
+			\PrestaShopLogger::addLog('[INFO] User paid after expiration for this invoice', \PrestaShopLogger::LOG_SEVERITY_LEVEL_INFORMATIVE, null, 'Order', $order->id);
+		}
+
+		// Add a message if the overpaid
+		if ($invoice->isOverpaid()) {
+			\PrestaShopLogger::addLog('[INFO] User overpaid for this order', \PrestaShopLogger::LOG_SEVERITY_LEVEL_INFORMATIVE, null, 'Order', $order->id);
+		}
+
+		// Update the object
+		if (false === $bitcoinPayment->update(true)) {
+			$error = \sprintf('[ERROR] Could not update bitcoin_payment: %s', \Db::getInstance()->getMsgError());
+			\PrestaShopLogger::addLog($error, \PrestaShopLogger::LOG_SEVERITY_LEVEL_ERROR, null, 'BitcoinPayment', $bitcoinPayment->getId());
+
+			throw new \RuntimeException($error);
+		}
+	}
+}

--- a/modules/btcpay/src/LegacyBitcoinPaymentRepository.php
+++ b/modules/btcpay/src/LegacyBitcoinPaymentRepository.php
@@ -32,7 +32,7 @@ class LegacyBitcoinPaymentRepository
 			throw new \RuntimeException('[ERROR] Could not store bitcoin_payment');
 		}
 
-		\PrestaShopLogger::addLog('[INFO] Created bitcoin_payment for invoice ' . $invoiceId);
+		\PrestaShopLogger::addLog('[INFO] Created bitcoin_payment for invoice ' . $invoiceId, \PrestaShopLogger::LOG_SEVERITY_LEVEL_INFORMATIVE, null, 'BitcoinPayment', $bitcoinPayment->getId());
 
 		return $bitcoinPayment;
 	}

--- a/modules/btcpay/src/LegacyBitcoinPaymentRepository.php
+++ b/modules/btcpay/src/LegacyBitcoinPaymentRepository.php
@@ -27,7 +27,7 @@ class LegacyBitcoinPaymentRepository
 		$bitcoinPayment->setInvoiceId($invoiceId);
 
 		if (false === $bitcoinPayment->save(true)) {
-			\PrestaShopLogger::addLog('[ERROR] Could not store bitcoin_payment', 3);
+			\PrestaShopLogger::addLog('[ERROR] Could not store bitcoin_payment', \PrestaShopLogger::LOG_SEVERITY_LEVEL_ERROR);
 
 			throw new \RuntimeException('[ERROR] Could not store bitcoin_payment');
 		}

--- a/modules/btcpay/src/Server/Factory.php
+++ b/modules/btcpay/src/Server/Factory.php
@@ -53,7 +53,7 @@ class Factory
 	{
 		// Check if we have a cart ID we can use
 		if (empty($cart->id)) {
-			\PrestaShopLogger::addLog('[ERROR] The BTCPay payment plugin was called to process a payment but the cart ID was missing.', 3);
+			\PrestaShopLogger::addLog('[ERROR] The BTCPay payment plugin was called to process a payment but the cart ID was missing.', \PrestaShopLogger::LOG_SEVERITY_LEVEL_ERROR);
 
 			return null;
 		}
@@ -62,7 +62,7 @@ class Factory
 		try {
 			$client = Client::createFromConfiguration($this->configuration);
 		} catch (\Throwable $e) {
-			\PrestaShopLogger::addLog(\sprintf('[ERROR] %s', $e->getMessage()), 4, $e->getCode());
+			\PrestaShopLogger::addLog(\sprintf('[ERROR] %s', $e->getMessage()), \PrestaShopLogger::LOG_SEVERITY_LEVEL_MAJOR, $e->getCode());
 
 			throw new BTCPayException($e->getMessage(), $e->getCode(), $e);
 		}
@@ -72,7 +72,7 @@ class Factory
 
 		// If another BTCPay invoice was created before, returns the original one
 		if (null !== ($redirect = $client->getBTCPayRedirect($cart))) {
-			\PrestaShopLogger::addLog(\sprintf('[WARNING] Existing BTCPay invoice has already been created for cart ID %s, redirecting...', $cart->id), 2);
+			\PrestaShopLogger::addLog(\sprintf('[WARNING] Existing BTCPay invoice has already been created for cart ID %s, redirecting...', $cart->id), \PrestaShopLogger::LOG_SEVERITY_LEVEL_WARNING);
 
 			return $redirect;
 		}
@@ -131,7 +131,7 @@ class Factory
 
 			if (false === $bitcoinPayment->save(true)) {
 				$error = \sprintf('[ERROR] Could not store bitcoin_payment: %s', \Db::getInstance()->getMsgError());
-				\PrestaShopLogger::addLog($error, 3);
+				\PrestaShopLogger::addLog($error, \PrestaShopLogger::LOG_SEVERITY_LEVEL_ERROR);
 
 				throw new \RuntimeException($error);
 			}
@@ -159,7 +159,7 @@ class Factory
 			// Update the object
 			if (false === $bitcoinPayment->update(true)) {
 				$error = \sprintf('[ERROR] Could not update bitcoin_payment: %s', \Db::getInstance()->getMsgError());
-				\PrestaShopLogger::addLog($error, 3);
+				\PrestaShopLogger::addLog($error, \PrestaShopLogger::LOG_SEVERITY_LEVEL_ERROR);
 
 				throw new \RuntimeException($error);
 			}
@@ -167,7 +167,7 @@ class Factory
 			// Redirect user to payment
 			return $bitcoinPayment->getRedirect();
 		} catch (\Throwable $e) {
-			\PrestaShopLogger::addLog(\sprintf('[ERROR] %s', $e->getMessage()), 3);
+			\PrestaShopLogger::addLog(\sprintf('[ERROR] %s', $e->getMessage()), \PrestaShopLogger::LOG_SEVERITY_LEVEL_ERROR);
 
 			throw new BTCPayException($e->getMessage(), $e->getCode(), $e);
 		}

--- a/modules/btcpay/src/Server/Webhook.php
+++ b/modules/btcpay/src/Server/Webhook.php
@@ -33,7 +33,7 @@ class Webhook extends \BTCPayServer\Client\Webhook
 		try {
 			return $this->getWebhook($storeId, $webhookId);
 		} catch (\Throwable $e) {
-			$warning = \sprintf("[Warning] expected webhook '%s' for store '%s' to exist, but it didn't. Exception received: %s", $webhookId, $storeId, $e->getMessage());
+			$warning = \sprintf("[WARNING] expected webhook '%s' for store '%s' to exist, but it didn't. Exception received: %s", $webhookId, $storeId, $e->getMessage());
 			\PrestaShopLogger::addLog($warning, \PrestaShopLogger::LOG_SEVERITY_LEVEL_WARNING, $e->getCode());
 
 			return null;

--- a/modules/btcpay/src/Server/WebhookHandler.php
+++ b/modules/btcpay/src/Server/WebhookHandler.php
@@ -102,7 +102,7 @@ class WebhookHandler
 		if (null === ($bitcoinPayment = $this->repository->getOneByInvoiceID($invoiceId))) {
 			$error = \sprintf('[ERROR] Could not load order with invoice ID %s', $invoiceId);
 			\PrestaShopLogger::addLog(\sprintf('[ERROR] Received IPN: %s', \json_encode($data, \JSON_THROW_ON_ERROR)));
-			\PrestaShopLogger::addLog($error, 4);
+			\PrestaShopLogger::addLog($error, \PrestaShopLogger::LOG_SEVERITY_LEVEL_MAJOR);
 
 			// Don't bother retrying, Prestashop should have sent email
 			return;
@@ -116,19 +116,19 @@ class WebhookHandler
 
 		// If nothing changed, return
 		if ((string) $order->current_state === $orderStatus) {
-			\PrestaShopLogger::addLog('[INFO] The state is the same as the one received', 1, null, 'Order', $order->id);
+			\PrestaShopLogger::addLog('[INFO] The state is the same as the one received', \PrestaShopLogger::LOG_SEVERITY_LEVEL_INFORMATIVE, null, 'Order', $order->id);
 
 			return;
 		}
 
 		// Add a message if the user paid too late
 		if (\array_key_exists('afterExpiration', $data) && true === (bool) $data['afterExpiration']) {
-			\PrestaShopLogger::addLog('[INFO] User paid after expiration for this invoice', 1, null, 'Order', $order->id);
+			\PrestaShopLogger::addLog('[INFO] User paid after expiration for this invoice', \PrestaShopLogger::LOG_SEVERITY_LEVEL_INFORMATIVE, null, 'Order', $order->id);
 		}
 
 		// Add a message if the user paid too late
 		if (\array_key_exists('overPaid', $data) && true === (bool) $data['overPaid']) {
-			\PrestaShopLogger::addLog('[INFO] User overpaid for this order', 1, null, 'Order', $order->id);
+			\PrestaShopLogger::addLog('[INFO] User overpaid for this order', \PrestaShopLogger::LOG_SEVERITY_LEVEL_INFORMATIVE, null, 'Order', $order->id);
 		}
 
 		// Update the status
@@ -137,7 +137,7 @@ class WebhookHandler
 		// Update the object
 		if (false === $bitcoinPayment->update(true)) {
 			$error = '[ERROR] Could not update bitcoin_payment: ' . \Db::getInstance()->getMsgError();
-			\PrestaShopLogger::addLog($error, 3);
+			\PrestaShopLogger::addLog($error, \PrestaShopLogger::LOG_SEVERITY_LEVEL_ERROR);
 
 			throw new \RuntimeException($error);
 		}
@@ -164,7 +164,7 @@ class WebhookHandler
 		if (null === ($bitcoinPayment = $this->repository->getOneByInvoiceID($invoiceId))) {
 			$error = \sprintf('[ERROR] Could not load order with invoice ID %s', $invoiceId);
 			\PrestaShopLogger::addLog(\sprintf('[ERROR] Received IPN: %s', \json_encode($data, \JSON_THROW_ON_ERROR)));
-			\PrestaShopLogger::addLog($error, 4);
+			\PrestaShopLogger::addLog($error, \PrestaShopLogger::LOG_SEVERITY_LEVEL_MAJOR);
 
 			// Don't bother retrying, Prestashop should have sent email
 			return;
@@ -195,7 +195,7 @@ class WebhookHandler
 
 		// If nothing changed, return
 		if ((string) $order->current_state === $orderStatus) {
-			\PrestaShopLogger::addLog('[INFO] The state is the same as the one received', 1, null, 'Order', $order->id);
+			\PrestaShopLogger::addLog('[INFO] The state is the same as the one received', \PrestaShopLogger::LOG_SEVERITY_LEVEL_INFORMATIVE, null, 'Order', $order->id);
 
 			return;
 		}
@@ -206,7 +206,7 @@ class WebhookHandler
 		// Update the object
 		if (false === $bitcoinPayment->update(true)) {
 			$error = \sprintf('[ERROR] Could not update bitcoin_payment: %s', \Db::getInstance()->getMsgError());
-			\PrestaShopLogger::addLog($error, 3);
+			\PrestaShopLogger::addLog($error, \PrestaShopLogger::LOG_SEVERITY_LEVEL_ERROR);
 
 			throw new \RuntimeException($error);
 		}
@@ -233,7 +233,7 @@ class WebhookHandler
 		if (null === ($bitcoinPayment = $this->repository->getOneByInvoiceID($invoiceId))) {
 			$error = \sprintf('[ERROR] Could not load order with invoice ID %s', $invoiceId);
 			\PrestaShopLogger::addLog(\sprintf('[ERROR] Received IPN: %s', \json_encode($data, \JSON_THROW_ON_ERROR)));
-			\PrestaShopLogger::addLog($error, 4);
+			\PrestaShopLogger::addLog($error, \PrestaShopLogger::LOG_SEVERITY_LEVEL_MAJOR);
 
 			// Don't bother retrying, Prestashop should have sent email
 			return;
@@ -265,12 +265,12 @@ class WebhookHandler
 
 		// Add a message if the user paid too late
 		if (\array_key_exists('afterExpiration', $data) && true === (bool) $data['afterExpiration']) {
-			\PrestaShopLogger::addLog('[INFO] User paid after expiration for this invoice', 1, null, 'Order', $order->id);
+			\PrestaShopLogger::addLog('[INFO] User paid after expiration for this invoice', \PrestaShopLogger::LOG_SEVERITY_LEVEL_INFORMATIVE, null, 'Order', $order->id);
 		}
 
 		// Add a message if the overpaid
 		if (\array_key_exists('overPaid', $data) && true === (bool) $data['overPaid']) {
-			\PrestaShopLogger::addLog('[INFO] User overpaid for this order', 1, null, 'Order', $order->id);
+			\PrestaShopLogger::addLog('[INFO] User overpaid for this order', \PrestaShopLogger::LOG_SEVERITY_LEVEL_INFORMATIVE, null, 'Order', $order->id);
 		}
 
 		if ($invoice->isMarked()) {
@@ -280,7 +280,7 @@ class WebhookHandler
 
 		// If nothing changed, return
 		if ((string) $order->current_state === $orderStatus) {
-			\PrestaShopLogger::addLog('[INFO] The state is the same as the one received', 1, null, 'Order', $order->id);
+			\PrestaShopLogger::addLog('[INFO] The state is the same as the one received', \PrestaShopLogger::LOG_SEVERITY_LEVEL_INFORMATIVE, null, 'Order', $order->id);
 
 			return;
 		}
@@ -291,7 +291,7 @@ class WebhookHandler
 		// Update the object
 		if (false === $bitcoinPayment->update(true)) {
 			$error = \sprintf('[ERROR] Could not update bitcoin_payment: %s', \Db::getInstance()->getMsgError());
-			\PrestaShopLogger::addLog($error, 3);
+			\PrestaShopLogger::addLog($error, \PrestaShopLogger::LOG_SEVERITY_LEVEL_ERROR);
 
 			throw new \RuntimeException($error);
 		}

--- a/modules/btcpay/views/templates/admin/configure.html.twig
+++ b/modules/btcpay/views/templates/admin/configure.html.twig
@@ -25,6 +25,7 @@
           <div class="card-text">
             {{ form_row(form.btcpay.url) }}
             {{ form_row(form.btcpay.speed) }}
+            {{ form_row(form.btcpay.order_mode) }}
             {{ form_row(form.btcpay.share_metadata) }}
             {{ form_rest(form) }}
           </div>
@@ -96,7 +97,7 @@
                 <dt><span class="text-muted mb-0"><strong>API Key</strong></span></dt>
                 <dd><span class="px-1">{{ client.apiKey().getCurrent().apiKey }}</span></dd>
 
-                {% set webhook = client.webhook().getCurrent(storeId) %}
+                {% set webhook = client.webhook().getCurrent(storeId, webhookId) %}
                 <dt><span class="text-muted mb-0"><strong>Webhook ID</strong></span></dt>
                 <dd><span class="{% if webhook.enabled %}text-success{% else %}text-warning{% endif %} px-1">{{ webhook.id }}</span></dd>
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Brings back the `order after payment`-option. It works a bit different and should be more robust overal. <br/> A user can now come back before the callback has been received/process, since the module will fetch the data from BTCPay Server itself and process it.
| Type?         | bug fix + improvement 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes btcpayserver/prestashop-plugin#40

---

/cc @celi28 if you could test this new version for me, that would be great. You can install the attached ZIP as is (no need to remove the old one). After that, configure the module and change the `Order creation method`-setting to `Order after payment`.

[btcpay.zip](https://github.com/btcpayserver/prestashop-plugin/files/8293389/btcpay.zip)