### PR TITLE
Allow API key to be set, in case redirection fails

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -3,8 +3,8 @@ name: "Validate"
 on: [ "pull_request" ]
 
 jobs:
-  linting:
-    name: "Linting (PHP ${{ matrix.php-versions }})"
+  security:
+    name: "Local PHP Security Checker (PHP ${{ matrix.php-versions }})"
     runs-on: "ubuntu-latest"
     strategy:
       fail-fast: true
@@ -14,7 +14,7 @@ jobs:
       - name: "Checkout"
         uses: "actions/checkout@v3"
       - name: "Setup PHP, with composer and extensions"
-        uses: "shivammathur/setup-php@v2" # https://github.com/shivammathur/setup-php
+        uses: "shivammathur/setup-php@v2"
         with:
           php-version: "${{ matrix.php-versions }}"
           extensions: "mbstring, xml, ctype, iconv, intl, gd"
@@ -32,6 +32,14 @@ jobs:
       - name: "Install Composer dependencies"
         run: "composer install --prefer-dist --no-progress --no-suggest --optimize-autoloader"
 
-      # Ensure our code looks proper
-      - name: "Lint the code"
-        run: "make lint"
+      # Ensure our dependencies are fine
+      - name: "Cache vulnerability database"
+        uses: "actions/cache@v3"
+        with:
+          path: "~/.cache/local-php-security-checker"
+          key: "local-php-security-checker-cache"
+      - name: "Local PHP Security Checker"
+        uses: "docker://pplotka/local-php-security-checker-github-actions"
+        with:
+          path: "./modules/btcpay/composer.lock"
+          cache_dir: "~/.cache/local-php-security-checker"

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,9 @@ lint: ## Lints the module
 	# Run PHPCS
 	@./vendor/bin/phpcs --cache -p
 
+	# Run PHP Parallel Lint
+	@./vendor/bin/parallel-lint --exclude ./modules/btcpay/vendor ./modules/btcpay
+
 lint-fix: ## Resolves linter issues
 	# Run PHP CS Fixer
 	@./vendor/bin/php-cs-fixer fix -v

--- a/README.md
+++ b/README.md
@@ -15,17 +15,17 @@ This is a Bitcoin payment plugin for PrestaShop using BTCPay server. [BTCPay Ser
 Please ensure that you meet the following requirements before installing this plugin.
 
 - You are using PHP 7.3.0 or higher
-- Your PrestaShop is version 1.7.7.0 or higher.
+- Your PrestaShop is version 1.7.8.0 or higher.
 - Your BTCPay Server is version 1.3.0 or higher
 - The PDO, curl, gd, intl, json, and mbstring PHP extensions are available
-- You have a BTCPay Server, either [self-hosted](https://docs.btcpayserver.org/Deployment/) or [hosted by a third-party](https://docs.btcpayserver.org/Deployment/ThirdPartyHosting/)
+- You have a BTCPay Server, either [self-hosted](https://docs.btcpayserver.org/Deployment/) or [hosted by a third party](https://docs.btcpayserver.org/Deployment/ThirdPartyHosting/)
 - [You've a registered account on the instance](https://docs.btcpayserver.org/RegisterAccount)
 - [You've a BTCPay store on the instance](https://docs.btcpayserver.org/CreateStore)
 - [You've a wallet connected to your store](https://docs.btcpayserver.org/WalletSetup)
 
 ### Tested successfully
-- Prestashop version 1.7.7.x up to 1.7.8.5
-- BTCPay server version 1.3.4 up to 1.5.0
+- Prestashop version 1.7.8.x up to 1.7.8.7
+- BTCPay server version 1.3.4 up to 1.6.12.0
 
 ## Multistore
 

--- a/composer.json
+++ b/composer.json
@@ -36,11 +36,13 @@
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^v0.7.2",
     "ergebnis/composer-normalize": "^v2.20.0",
+    "ezyang/htmlpurifier": "dev-master as v4.14.0",
     "friendsofphp/php-cs-fixer": "^v3.4",
+    "php-parallel-lint/php-console-highlighter": "^1.0",
+    "php-parallel-lint/php-parallel-lint": "^1.3",
     "prestashop/php-dev-tools": "^v4.2.1",
     "prestashop/prestashop": "dev-develop",
     "roave/security-advisories": "dev-latest",
-    "ezyang/htmlpurifier": "dev-master as v4.14.0",
     "slevomat/coding-standard": "^v7.2.1",
     "squizlabs/php_codesniffer": "^v3.7.1"
   },
@@ -58,7 +60,7 @@
     "prestashop/gridhtml": "^v2",
     "prestashop/gsitemap": "^v4",
     "prestashop/pagesnotfound": "^v2",
-    "prestashop/productcomments": "^v5.0",
+    "prestashop/productcomments": "^v5.0.2",
     "prestashop/ps_banner": "^v2",
     "prestashop/ps_bestsellers": "^v1.0",
     "prestashop/ps_brandlist": "^v1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "10364363a6d7d92477eb40281e2a2a69",
+    "content-hash": "da64a7a2e476cc39f3bad91109753a13",
     "packages": [
         {
             "name": "composer/installers",
@@ -273,16 +273,16 @@
         },
         {
             "name": "composer/ca-bundle",
-            "version": "1.3.3",
+            "version": "1.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "30897edbfb15e784fe55587b4f73ceefd3c4d98c"
+                "reference": "69098eca243998b53eed7a48d82dedd28b447cd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/30897edbfb15e784fe55587b4f73ceefd3c4d98c",
-                "reference": "30897edbfb15e784fe55587b4f73ceefd3c4d98c",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/69098eca243998b53eed7a48d82dedd28b447cd5",
+                "reference": "69098eca243998b53eed7a48d82dedd28b447cd5",
                 "shasum": ""
             },
             "require": {
@@ -329,7 +329,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.3.3"
+                "source": "https://github.com/composer/ca-bundle/tree/1.3.4"
             },
             "funding": [
                 {
@@ -345,7 +345,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-07-20T07:14:26+00:00"
+            "time": "2022-10-12T12:08:29+00:00"
         },
         {
             "name": "composer/pcre",
@@ -618,16 +618,16 @@
         },
         {
             "name": "curl/curl",
-            "version": "2.3.3",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-mod/curl.git",
-                "reference": "ec22ad27dead47093f0944f5e651df4b12846f5a"
+                "reference": "ba385e40c5907850c555db24505c127fe29f1e44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-mod/curl/zipball/ec22ad27dead47093f0944f5e651df4b12846f5a",
-                "reference": "ec22ad27dead47093f0944f5e651df4b12846f5a",
+                "url": "https://api.github.com/repos/php-mod/curl/zipball/ba385e40c5907850c555db24505c127fe29f1e44",
+                "reference": "ba385e40c5907850c555db24505c127fe29f1e44",
                 "shasum": ""
             },
             "require": {
@@ -670,9 +670,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-mod/curl/issues",
-                "source": "https://github.com/php-mod/curl/tree/2.3.3"
+                "source": "https://github.com/php-mod/curl/tree/2.4.0"
             },
-            "time": "2021-11-30T20:19:35+00:00"
+            "time": "2022-08-29T08:52:24+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -983,16 +983,16 @@
         },
         {
             "name": "doctrine/collections",
-            "version": "1.7.0",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/collections.git",
-                "reference": "07d15c8a766e664ec271ae84e5dfc597aeeb03b1"
+                "reference": "2b44dd4cbca8b5744327de78bafef5945c7e7b5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/collections/zipball/07d15c8a766e664ec271ae84e5dfc597aeeb03b1",
-                "reference": "07d15c8a766e664ec271ae84e5dfc597aeeb03b1",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/2b44dd4cbca8b5744327de78bafef5945c7e7b5e",
+                "reference": "2b44dd4cbca8b5744327de78bafef5945c7e7b5e",
                 "shasum": ""
             },
             "require": {
@@ -1000,7 +1000,7 @@
                 "php": "^7.1.3 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9.0",
+                "doctrine/coding-standard": "^9.0 || ^10.0",
                 "phpstan/phpstan": "^1.4.8",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.1.5",
                 "vimeo/psalm": "^4.22"
@@ -1047,22 +1047,22 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/collections/issues",
-                "source": "https://github.com/doctrine/collections/tree/1.7.0"
+                "source": "https://github.com/doctrine/collections/tree/1.8.0"
             },
-            "time": "2022-08-18T05:44:45+00:00"
+            "time": "2022-09-01T20:12:10+00:00"
         },
         {
             "name": "doctrine/common",
-            "version": "3.3.1",
+            "version": "3.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/common.git",
-                "reference": "6a76bd25b1030d35d6ba2bf2f69ca858a41fc580"
+                "reference": "8b5e5650391f851ed58910b3e3d48a71062eeced"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/common/zipball/6a76bd25b1030d35d6ba2bf2f69ca858a41fc580",
-                "reference": "6a76bd25b1030d35d6ba2bf2f69ca858a41fc580",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/8b5e5650391f851ed58910b3e3d48a71062eeced",
+                "reference": "8b5e5650391f851ed58910b3e3d48a71062eeced",
                 "shasum": ""
             },
             "require": {
@@ -1070,19 +1070,19 @@
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9.0",
+                "doctrine/coding-standard": "^9.0 || ^10.0",
                 "doctrine/collections": "^1",
                 "phpstan/phpstan": "^1.4.1",
                 "phpstan/phpstan-phpunit": "^1",
                 "phpunit/phpunit": "^7.5.20 || ^8.5 || ^9.0",
                 "squizlabs/php_codesniffer": "^3.0",
-                "symfony/phpunit-bridge": "^4.0.5",
+                "symfony/phpunit-bridge": "^6.1",
                 "vimeo/psalm": "^4.4"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                    "Doctrine\\Common\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1124,7 +1124,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/common/issues",
-                "source": "https://github.com/doctrine/common/tree/3.3.1"
+                "source": "https://github.com/doctrine/common/tree/3.4.3"
             },
             "funding": [
                 {
@@ -1140,7 +1140,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-20T10:48:54+00:00"
+            "time": "2022-10-09T11:47:59+00:00"
         },
         {
             "name": "doctrine/dbal",
@@ -1412,34 +1412,35 @@
         },
         {
             "name": "doctrine/event-manager",
-            "version": "1.1.2",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/event-manager.git",
-                "reference": "eb2ecf80e3093e8f3c2769ac838e27d8ede8e683"
+                "reference": "95aa4cb529f1e96576f3fda9f5705ada4056a520"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/eb2ecf80e3093e8f3c2769ac838e27d8ede8e683",
-                "reference": "eb2ecf80e3093e8f3c2769ac838e27d8ede8e683",
+                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/95aa4cb529f1e96576f3fda9f5705ada4056a520",
+                "reference": "95aa4cb529f1e96576f3fda9f5705ada4056a520",
                 "shasum": ""
             },
             "require": {
+                "doctrine/deprecations": "^0.5.3 || ^1",
                 "php": "^7.1 || ^8.0"
             },
             "conflict": {
                 "doctrine/common": "<2.9"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9",
-                "phpstan/phpstan": "~1.4.10 || ^1.5.4",
+                "doctrine/coding-standard": "^9 || ^10",
+                "phpstan/phpstan": "~1.4.10 || ^1.8.8",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.22"
+                "vimeo/psalm": "^4.24"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                    "Doctrine\\Common\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1483,7 +1484,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/event-manager/issues",
-                "source": "https://github.com/doctrine/event-manager/tree/1.1.2"
+                "source": "https://github.com/doctrine/event-manager/tree/1.2.0"
             },
             "funding": [
                 {
@@ -1499,32 +1500,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-07-27T22:18:11+00:00"
+            "time": "2022-10-12T20:51:15+00:00"
         },
         {
             "name": "doctrine/inflector",
-            "version": "2.0.4",
+            "version": "2.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/inflector.git",
-                "reference": "8b7ff3e4b7de6b2c84da85637b59fd2880ecaa89"
+                "reference": "ade2b3bbfb776f27f0558e26eed43b5d9fe1b392"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/8b7ff3e4b7de6b2c84da85637b59fd2880ecaa89",
-                "reference": "8b7ff3e4b7de6b2c84da85637b59fd2880ecaa89",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/ade2b3bbfb776f27f0558e26eed43b5d9fe1b392",
+                "reference": "ade2b3bbfb776f27f0558e26eed43b5d9fe1b392",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^8.2",
-                "phpstan/phpstan": "^0.12",
-                "phpstan/phpstan-phpunit": "^0.12",
-                "phpstan/phpstan-strict-rules": "^0.12",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
-                "vimeo/psalm": "^4.10"
+                "doctrine/coding-standard": "^9",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.3",
+                "phpunit/phpunit": "^8.5 || ^9.5",
+                "vimeo/psalm": "^4.25"
             },
             "type": "library",
             "autoload": {
@@ -1574,7 +1575,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/inflector/issues",
-                "source": "https://github.com/doctrine/inflector/tree/2.0.4"
+                "source": "https://github.com/doctrine/inflector/tree/2.0.5"
             },
             "funding": [
                 {
@@ -1590,7 +1591,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-10-22T20:16:43+00:00"
+            "time": "2022-09-07T09:01:28+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -1740,16 +1741,16 @@
         },
         {
             "name": "doctrine/orm",
-            "version": "2.13.1",
+            "version": "2.13.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/orm.git",
-                "reference": "35c44a56677adb3ce796138b6e4934ce93ec6811"
+                "reference": "e750360bd52b080c4cbaaee1b48b80f7dc873b36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/orm/zipball/35c44a56677adb3ce796138b6e4934ce93ec6811",
-                "reference": "35c44a56677adb3ce796138b6e4934ce93ec6811",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/e750360bd52b080c4cbaaee1b48b80f7dc873b36",
+                "reference": "e750360bd52b080c4cbaaee1b48b80f7dc873b36",
                 "shasum": ""
             },
             "require": {
@@ -1776,15 +1777,15 @@
             },
             "require-dev": {
                 "doctrine/annotations": "^1.13",
-                "doctrine/coding-standard": "^9.0",
+                "doctrine/coding-standard": "^9.0.2 || ^10.0",
                 "phpbench/phpbench": "^0.16.10 || ^1.0",
-                "phpstan/phpstan": "~1.4.10 || 1.8.2",
+                "phpstan/phpstan": "~1.4.10 || 1.8.5",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
                 "psr/log": "^1 || ^2 || ^3",
                 "squizlabs/php_codesniffer": "3.7.1",
                 "symfony/cache": "^4.4 || ^5.4 || ^6.0",
                 "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0",
-                "vimeo/psalm": "4.26.0"
+                "vimeo/psalm": "4.27.0"
             },
             "suggest": {
                 "ext-dom": "Provides support for XSD validation for XML mapping files",
@@ -1834,26 +1835,26 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/orm/issues",
-                "source": "https://github.com/doctrine/orm/tree/2.13.1"
+                "source": "https://github.com/doctrine/orm/tree/2.13.3"
             },
-            "time": "2022-08-08T09:00:16+00:00"
+            "time": "2022-10-07T06:37:17+00:00"
         },
         {
             "name": "doctrine/persistence",
-            "version": "3.0.3",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/persistence.git",
-                "reference": "ac6fce61f037d7e54dbb2435f5b5648d86548e23"
+                "reference": "05612da375f8a3931161f435f91d6704926e6ec5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/persistence/zipball/ac6fce61f037d7e54dbb2435f5b5648d86548e23",
-                "reference": "ac6fce61f037d7e54dbb2435f5b5648d86548e23",
+                "url": "https://api.github.com/repos/doctrine/persistence/zipball/05612da375f8a3931161f435f91d6704926e6ec5",
+                "reference": "05612da375f8a3931161f435f91d6704926e6ec5",
                 "shasum": ""
             },
             "require": {
-                "doctrine/event-manager": "^1.0",
+                "doctrine/event-manager": "^1 || ^2",
                 "php": "^7.2 || ^8.0",
                 "psr/cache": "^1.0 || ^2.0 || ^3.0"
             },
@@ -1864,14 +1865,14 @@
             "require-dev": {
                 "composer/package-versions-deprecated": "^1.11",
                 "doctrine/annotations": "^1.7",
-                "doctrine/coding-standard": "^9.0",
+                "doctrine/coding-standard": "^10",
                 "doctrine/common": "^3.0",
-                "phpstan/phpstan": "1.5.0",
+                "phpstan/phpstan": "1.8.8",
                 "phpstan/phpstan-phpunit": "^1",
                 "phpstan/phpstan-strict-rules": "^1.1",
                 "phpunit/phpunit": "^8.5 || ^9.5",
                 "symfony/cache": "^4.4 || ^5.4 || ^6.0",
-                "vimeo/psalm": "4.22.0"
+                "vimeo/psalm": "4.29.0"
             },
             "type": "library",
             "autoload": {
@@ -1920,7 +1921,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/persistence/issues",
-                "source": "https://github.com/doctrine/persistence/tree/3.0.3"
+                "source": "https://github.com/doctrine/persistence/tree/3.0.4"
             },
             "funding": [
                 {
@@ -1936,7 +1937,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-04T21:14:21+00:00"
+            "time": "2022-10-13T07:34:14+00:00"
         },
         {
             "name": "doctrine/sql-formatter",
@@ -2278,16 +2279,20 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ezyang/htmlpurifier.git",
-                "reference": "dff4746e133777583fbf43d2b95372e8d818df1f"
+                "reference": "e55fead09f39430d30f48438f06e7bc2326efc94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/dff4746e133777583fbf43d2b95372e8d818df1f",
-                "reference": "dff4746e133777583fbf43d2b95372e8d818df1f",
+                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/e55fead09f39430d30f48438f06e7bc2326efc94",
+                "reference": "e55fead09f39430d30f48438f06e7bc2326efc94",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.2"
+                "php": "~5.6.0 || ~7.0.0 || ~7.1.0 || ~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0"
+            },
+            "require-dev": {
+                "cerdic/css-tidy": "^1.7 || ^2.0",
+                "simpletest/simpletest": "dev-master"
             },
             "suggest": {
                 "cerdic/css-tidy": "If you want to use the filter 'Filter.ExtractStyleBlocks'.",
@@ -2328,7 +2333,7 @@
                 "issues": "https://github.com/ezyang/htmlpurifier/issues",
                 "source": "https://github.com/ezyang/htmlpurifier/tree/master"
             },
-            "time": "2022-08-16T02:59:31+00:00"
+            "time": "2022-09-20T16:45:11+00:00"
         },
         {
             "name": "friendsofphp/php-cs-fixer",
@@ -2684,16 +2689,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.4.5",
+            "version": "7.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "1dd98b0564cb3f6bd16ce683cb755f94c10fbd82"
+                "reference": "b50a2a1251152e43f6a37f0fa053e730a67d25ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/1dd98b0564cb3f6bd16ce683cb755f94c10fbd82",
-                "reference": "1dd98b0564cb3f6bd16ce683cb755f94c10fbd82",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b50a2a1251152e43f6a37f0fa053e730a67d25ba",
+                "reference": "b50a2a1251152e43f6a37f0fa053e730a67d25ba",
                 "shasum": ""
             },
             "require": {
@@ -2708,10 +2713,10 @@
                 "psr/http-client-implementation": "1.0"
             },
             "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.4.1",
+                "bamarni/composer-bin-plugin": "^1.8.1",
                 "ext-curl": "*",
                 "php-http/client-integration-tests": "^3.0",
-                "phpunit/phpunit": "^8.5.5 || ^9.3.5",
+                "phpunit/phpunit": "^8.5.29 || ^9.5.23",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -2721,8 +2726,12 @@
             },
             "type": "library",
             "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                },
                 "branch-alias": {
-                    "dev-master": "7.4-dev"
+                    "dev-master": "7.5-dev"
                 }
             },
             "autoload": {
@@ -2788,7 +2797,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.4.5"
+                "source": "https://github.com/guzzle/guzzle/tree/7.5.0"
             },
             "funding": [
                 {
@@ -2804,20 +2813,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-20T22:16:13+00:00"
+            "time": "2022-08-28T15:39:27+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "1.5.1",
+            "version": "1.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "fe752aedc9fd8fcca3fe7ad05d419d32998a06da"
+                "reference": "b94b2807d85443f9719887892882d0329d1e2598"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/fe752aedc9fd8fcca3fe7ad05d419d32998a06da",
-                "reference": "fe752aedc9fd8fcca3fe7ad05d419d32998a06da",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/b94b2807d85443f9719887892882d0329d1e2598",
+                "reference": "b94b2807d85443f9719887892882d0329d1e2598",
                 "shasum": ""
             },
             "require": {
@@ -2872,7 +2881,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/1.5.1"
+                "source": "https://github.com/guzzle/promises/tree/1.5.2"
             },
             "funding": [
                 {
@@ -2888,20 +2897,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-10-22T20:56:57+00:00"
+            "time": "2022-08-28T14:55:35+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.4.0",
+            "version": "2.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "13388f00956b1503577598873fffb5ae994b5737"
+                "reference": "69568e4293f4fa993f3b0e51c9723e1e17c41379"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/13388f00956b1503577598873fffb5ae994b5737",
-                "reference": "13388f00956b1503577598873fffb5ae994b5737",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/69568e4293f4fa993f3b0e51c9723e1e17c41379",
+                "reference": "69568e4293f4fa993f3b0e51c9723e1e17c41379",
                 "shasum": ""
             },
             "require": {
@@ -2915,15 +2924,19 @@
                 "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.4.1",
+                "bamarni/composer-bin-plugin": "^1.8.1",
                 "http-interop/http-factory-tests": "^0.9",
-                "phpunit/phpunit": "^8.5.8 || ^9.3.10"
+                "phpunit/phpunit": "^8.5.29 || ^9.5.23"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
             },
             "type": "library",
             "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                },
                 "branch-alias": {
                     "dev-master": "2.4-dev"
                 }
@@ -2987,7 +3000,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.4.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.4.1"
             },
             "funding": [
                 {
@@ -3003,7 +3016,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-20T21:43:11+00:00"
+            "time": "2022-08-28T14:45:39+00:00"
         },
         {
             "name": "incenteev/composer-parameter-handler",
@@ -4409,22 +4422,22 @@
         },
         {
             "name": "mrclay/minify",
-            "version": "3.0.12",
+            "version": "3.0.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mrclay/minify.git",
-                "reference": "1962d3614c7ee1795a9fb74e49e603646b34207d"
+                "reference": "ae5b9f0bfb5f2ab0bcba45289268328be27a7ae6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mrclay/minify/zipball/1962d3614c7ee1795a9fb74e49e603646b34207d",
-                "reference": "1962d3614c7ee1795a9fb74e49e603646b34207d",
+                "url": "https://api.github.com/repos/mrclay/minify/zipball/ae5b9f0bfb5f2ab0bcba45289268328be27a7ae6",
+                "reference": "ae5b9f0bfb5f2ab0bcba45289268328be27a7ae6",
                 "shasum": ""
             },
             "require": {
                 "ext-pcre": "*",
                 "intervention/httpauth": "^2.0|^3.0",
-                "marcusschwarz/lesserphp": "^0.5.1",
+                "marcusschwarz/lesserphp": "^0.5.5",
                 "monolog/monolog": "~1.1|~2.0",
                 "mrclay/jsmin-php": "~2",
                 "mrclay/props-dic": "^2.2|^3.0",
@@ -4469,10 +4482,10 @@
             "support": {
                 "email": "minify@googlegroups.com",
                 "issues": "https://github.com/mrclay/minify/issues",
-                "source": "https://github.com/mrclay/minify/tree/3.0.12",
+                "source": "https://github.com/mrclay/minify/tree/3.0.13",
                 "wiki": "https://github.com/mrclay/minify/blob/master/docs"
             },
-            "time": "2022-05-14T11:11:27+00:00"
+            "time": "2022-10-02T21:12:43+00:00"
         },
         {
             "name": "mrclay/props-dic",
@@ -4594,16 +4607,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.14.0",
+            "version": "v4.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "34bea19b6e03d8153165d8f30bba4c3be86184c1"
+                "reference": "0ef6c55a3f47f89d7a374e6f835197a0b5fcf900"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/34bea19b6e03d8153165d8f30bba4c3be86184c1",
-                "reference": "34bea19b6e03d8153165d8f30bba4c3be86184c1",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/0ef6c55a3f47f89d7a374e6f835197a0b5fcf900",
+                "reference": "0ef6c55a3f47f89d7a374e6f835197a0b5fcf900",
                 "shasum": ""
             },
             "require": {
@@ -4644,9 +4657,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.14.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.1"
             },
-            "time": "2022-05-31T20:59:12+00:00"
+            "time": "2022-09-04T07:30:47+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -5064,7 +5077,166 @@
                 "issues": "https://github.com/PHP-CS-Fixer/diff/issues",
                 "source": "https://github.com/PHP-CS-Fixer/diff/tree/v2.0.2"
             },
+            "abandoned": true,
             "time": "2020-10-14T08:32:19+00:00"
+        },
+        {
+            "name": "php-parallel-lint/php-console-color",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-parallel-lint/PHP-Console-Color.git",
+                "reference": "7adfefd530aa2d7570ba87100a99e2483a543b88"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-parallel-lint/PHP-Console-Color/zipball/7adfefd530aa2d7570ba87100a99e2483a543b88",
+                "reference": "7adfefd530aa2d7570ba87100a99e2483a543b88",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "replace": {
+                "jakub-onderka/php-console-color": "*"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-code-style": "^2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.0",
+                "php-parallel-lint/php-var-dump-check": "0.*",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHP_Parallel_Lint\\PhpConsoleColor\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jakub Onderka",
+                    "email": "jakub.onderka@gmail.com"
+                }
+            ],
+            "description": "Simple library for creating colored console ouput.",
+            "support": {
+                "issues": "https://github.com/php-parallel-lint/PHP-Console-Color/issues",
+                "source": "https://github.com/php-parallel-lint/PHP-Console-Color/tree/v1.0.1"
+            },
+            "time": "2021-12-25T06:49:29+00:00"
+        },
+        {
+            "name": "php-parallel-lint/php-console-highlighter",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-parallel-lint/PHP-Console-Highlighter.git",
+                "reference": "5b4803384d3303cf8e84141039ef56c8a123138d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-parallel-lint/PHP-Console-Highlighter/zipball/5b4803384d3303cf8e84141039ef56c8a123138d",
+                "reference": "5b4803384d3303cf8e84141039ef56c8a123138d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.3.2",
+                "php-parallel-lint/php-console-color": "^1.0.1"
+            },
+            "replace": {
+                "jakub-onderka/php-console-highlighter": "*"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-code-style": "^2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.0",
+                "php-parallel-lint/php-var-dump-check": "0.*",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHP_Parallel_Lint\\PhpConsoleHighlighter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jakub Onderka",
+                    "email": "acci@acci.cz",
+                    "homepage": "http://www.acci.cz/"
+                }
+            ],
+            "description": "Highlight PHP code in terminal",
+            "support": {
+                "issues": "https://github.com/php-parallel-lint/PHP-Console-Highlighter/issues",
+                "source": "https://github.com/php-parallel-lint/PHP-Console-Highlighter/tree/v1.0.0"
+            },
+            "time": "2022-02-18T08:23:19+00:00"
+        },
+        {
+            "name": "php-parallel-lint/php-parallel-lint",
+            "version": "v1.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-parallel-lint/PHP-Parallel-Lint.git",
+                "reference": "6483c9832e71973ed29cf71bd6b3f4fde438a9de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-parallel-lint/PHP-Parallel-Lint/zipball/6483c9832e71973ed29cf71bd6b3f4fde438a9de",
+                "reference": "6483c9832e71973ed29cf71bd6b3f4fde438a9de",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=5.3.0"
+            },
+            "replace": {
+                "grogy/php-parallel-lint": "*",
+                "jakub-onderka/php-parallel-lint": "*"
+            },
+            "require-dev": {
+                "nette/tester": "^1.3 || ^2.0",
+                "php-parallel-lint/php-console-highlighter": "0.* || ^1.0",
+                "squizlabs/php_codesniffer": "^3.6"
+            },
+            "suggest": {
+                "php-parallel-lint/php-console-highlighter": "Highlight syntax in code snippet"
+            },
+            "bin": [
+                "parallel-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "./src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jakub Onderka",
+                    "email": "ahoj@jakubonderka.cz"
+                }
+            ],
+            "description": "This tool check syntax of PHP files about 20x faster than serial check.",
+            "homepage": "https://github.com/php-parallel-lint/PHP-Parallel-Lint",
+            "support": {
+                "issues": "https://github.com/php-parallel-lint/PHP-Parallel-Lint/issues",
+                "source": "https://github.com/php-parallel-lint/PHP-Parallel-Lint/tree/v1.3.2"
+            },
+            "time": "2022-02-21T12:50:22+00:00"
         },
         {
             "name": "phpoffice/phpspreadsheet",
@@ -5172,16 +5344,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.7.0",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "367a8d9d5f7da2a0136422d27ce8840583926955"
+                "reference": "7d1e81213b0c7eb8d5a9f524456cbc2778ed5c65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/367a8d9d5f7da2a0136422d27ce8840583926955",
-                "reference": "367a8d9d5f7da2a0136422d27ce8840583926955",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/7d1e81213b0c7eb8d5a9f524456cbc2778ed5c65",
+                "reference": "7d1e81213b0c7eb8d5a9f524456cbc2778ed5c65",
                 "shasum": ""
             },
             "require": {
@@ -5211,9 +5383,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.7.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.11.0"
             },
-            "time": "2022-08-09T12:23:23+00:00"
+            "time": "2022-10-14T13:32:28+00:00"
         },
         {
             "name": "pimple/pimple",
@@ -5270,23 +5442,23 @@
         },
         {
             "name": "prestashop/autoindex",
-            "version": "v2.0.0",
+            "version": "v2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShopCorp/autoindex.git",
-                "reference": "355c224de4ca8766d63a038dcdcb24f56cb19fec"
+                "reference": "235f3ec115432ffc32d582198ea498467b3946d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShopCorp/autoindex/zipball/355c224de4ca8766d63a038dcdcb24f56cb19fec",
-                "reference": "355c224de4ca8766d63a038dcdcb24f56cb19fec",
+                "url": "https://api.github.com/repos/PrestaShopCorp/autoindex/zipball/235f3ec115432ffc32d582198ea498467b3946d0",
+                "reference": "235f3ec115432ffc32d582198ea498467b3946d0",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^4.10",
-                "php": ">=7.2",
-                "symfony/console": "^3.4 || ~4.0 || ~5.0",
-                "symfony/finder": "^3.4 || ~4.0 || ~5.0"
+                "php": "^8.0 || ^7.2",
+                "symfony/console": "^3.4 || ~4.0 || ~5.0 || ~6.0",
+                "symfony/finder": "^3.4 || ~4.0 || ~5.0 || ~6.0"
             },
             "require-dev": {
                 "phpstan/phpstan": "^0.12.83",
@@ -5314,9 +5486,9 @@
             "description": "Automatically add an 'index.php' in all the current or specified directories and all sub-directories.",
             "homepage": "https://github.com/PrestaShopCorp/autoindex",
             "support": {
-                "source": "https://github.com/PrestaShopCorp/autoindex/tree/v2.0.0"
+                "source": "https://github.com/PrestaShopCorp/autoindex/tree/v2.1.0"
             },
-            "time": "2021-06-09T15:37:17+00:00"
+            "time": "2022-10-10T08:35:00+00:00"
         },
         {
             "name": "prestashop/circuit-breaker",
@@ -5430,23 +5602,23 @@
         },
         {
             "name": "prestashop/header-stamp",
-            "version": "v2.1",
+            "version": "v2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShopCorp/header-stamp.git",
-                "reference": "d00c2ce550fe9b1a3713cebafee669f44a93ff2a"
+                "reference": "ae1533967ca797e7c8efd5bbbf4351d163253cf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShopCorp/header-stamp/zipball/d00c2ce550fe9b1a3713cebafee669f44a93ff2a",
-                "reference": "d00c2ce550fe9b1a3713cebafee669f44a93ff2a",
+                "url": "https://api.github.com/repos/PrestaShopCorp/header-stamp/zipball/ae1533967ca797e7c8efd5bbbf4351d163253cf4",
+                "reference": "ae1533967ca797e7c8efd5bbbf4351d163253cf4",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^4.10",
-                "php": ">=7.2.5",
-                "symfony/console": "^3.4 || ~4.0 || ~5.0",
-                "symfony/finder": "^3.4 || ~4.0 || ~5.0"
+                "php": "^8.0 || ^7.2",
+                "symfony/console": "^3.4 || ~4.0 || ~5.0 || ~6.0",
+                "symfony/finder": "^3.4 || ~4.0 || ~5.0 || ~6.0"
             },
             "require-dev": {
                 "phpstan/phpstan": "^0.12.83",
@@ -5475,9 +5647,9 @@
             "homepage": "https://github.com/PrestaShopCorp/header-stamp",
             "support": {
                 "issues": "https://github.com/PrestaShopCorp/header-stamp/issues",
-                "source": "https://github.com/PrestaShopCorp/header-stamp/tree/v2.1"
+                "source": "https://github.com/PrestaShopCorp/header-stamp/tree/v2.2"
             },
-            "time": "2021-11-15T16:57:29+00:00"
+            "time": "2022-10-10T08:26:55+00:00"
         },
         {
             "name": "prestashop/laminas-code-lts",
@@ -5598,12 +5770,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/PrestaShop.git",
-                "reference": "83079ee0c30a7aebe58086c9aef2022ff43203a9"
+                "reference": "c266d1fa09a55cd7e4c9c26ac1dbb8ce415f8091"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/PrestaShop/zipball/83079ee0c30a7aebe58086c9aef2022ff43203a9",
-                "reference": "83079ee0c30a7aebe58086c9aef2022ff43203a9",
+                "url": "https://api.github.com/repos/PrestaShop/PrestaShop/zipball/c266d1fa09a55cd7e4c9c26ac1dbb8ce415f8091",
+                "reference": "c266d1fa09a55cd7e4c9c26ac1dbb8ce415f8091",
                 "shasum": ""
             },
             "require": {
@@ -5650,7 +5822,7 @@
                 "prestashop/blockreassurance": "^5.1",
                 "prestashop/blockwishlist": "^2.0",
                 "prestashop/circuit-breaker": "^4.0",
-                "prestashop/classic": "^2.0.0-beta",
+                "prestashop/classic": "^2.0",
                 "prestashop/contactform": "^4",
                 "prestashop/dashactivity": "^2",
                 "prestashop/dashgoals": "^2",
@@ -5734,7 +5906,7 @@
             "require-dev": {
                 "behat/behat": "^3.5",
                 "ergebnis/composer-normalize": "^2.8",
-                "friendsofphp/php-cs-fixer": "^2.16.1",
+                "friendsofphp/php-cs-fixer": "^v3.2.0",
                 "johnkary/phpunit-speedtrap": "^3",
                 "mikey179/vfsstream": "^1.6",
                 "phpstan/phpstan": "^1",
@@ -5787,20 +5959,20 @@
                 "issues": "https://github.com/PrestaShop/PrestaShop/issues",
                 "source": "https://github.com/PrestaShop/PrestaShop/tree/develop"
             },
-            "time": "2022-08-17T08:08:13+00:00"
+            "time": "2022-10-14T18:19:04+00:00"
         },
         {
             "name": "prestashop/translationtools-bundle",
-            "version": "v5.0.3",
+            "version": "v5.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/TranslationToolsBundle.git",
-                "reference": "d7ad81008913ec1d988acdbb1a342e19f569e74d"
+                "reference": "4aaef89ee0b4913157a76559bed52f4f35b2fb70"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/TranslationToolsBundle/zipball/d7ad81008913ec1d988acdbb1a342e19f569e74d",
-                "reference": "d7ad81008913ec1d988acdbb1a342e19f569e74d",
+                "url": "https://api.github.com/repos/PrestaShop/TranslationToolsBundle/zipball/4aaef89ee0b4913157a76559bed52f4f35b2fb70",
+                "reference": "4aaef89ee0b4913157a76559bed52f4f35b2fb70",
                 "shasum": ""
             },
             "require": {
@@ -5847,9 +6019,9 @@
             ],
             "support": {
                 "issues": "https://github.com/PrestaShop/TranslationToolsBundle/issues",
-                "source": "https://github.com/PrestaShop/TranslationToolsBundle/tree/v5.0.3"
+                "source": "https://github.com/PrestaShop/TranslationToolsBundle/tree/v5.0.4"
             },
-            "time": "2022-03-16T07:57:53+00:00"
+            "time": "2022-09-01T08:33:26+00:00"
         },
         {
             "name": "psr/cache",
@@ -6311,12 +6483,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "bd4a45f60f097f0c44f77c6d72caa24ebc9b9f66"
+                "reference": "1d3484a08d3875e28bc2ad66697b0947cd6a2d99"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/bd4a45f60f097f0c44f77c6d72caa24ebc9b9f66",
-                "reference": "bd4a45f60f097f0c44f77c6d72caa24ebc9b9f66",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/1d3484a08d3875e28bc2ad66697b0947cd6a2d99",
+                "reference": "1d3484a08d3875e28bc2ad66697b0947cd6a2d99",
                 "shasum": ""
             },
             "conflict": {
@@ -6337,6 +6509,7 @@
                 "appwrite/server-ce": "<0.11.1|>=0.12,<0.12.2",
                 "area17/twill": "<1.2.5|>=2,<2.5.3",
                 "asymmetricrypt/asymmetricrypt": ">=0,<9.9.99",
+                "awesome-support/awesome-support": "<=6.0.7",
                 "aws/aws-sdk-php": ">=3,<3.2.1",
                 "bagisto/bagisto": "<0.1.5",
                 "barrelstrength/sprout-base-email": "<1.2.7",
@@ -6362,11 +6535,11 @@
                 "cart2quote/module-quotation": ">=4.1.6,<=4.4.5|>=5,<5.4.4",
                 "cartalyst/sentry": "<=2.1.6",
                 "catfan/medoo": "<1.7.5",
-                "centreon/centreon": "<20.10.7",
+                "centreon/centreon": "<21.4.16|>=21.10,<21.10.8|>=22,<22.4.1",
                 "cesnet/simplesamlphp-module-proxystatistics": "<3.1",
                 "codeception/codeception": "<3.1.3|>=4,<4.1.22",
                 "codeigniter/framework": "<=3.0.6",
-                "codeigniter4/framework": "<4.1.9",
+                "codeigniter4/framework": "<4.2.7",
                 "codeigniter4/shield": "= 1.0.0-beta",
                 "codiad/codiad": "<=2.8.4",
                 "composer/composer": "<1.10.26|>=2-alpha.1,<2.2.12|>=2.3,<2.3.5",
@@ -6378,7 +6551,7 @@
                 "contao/core-bundle": "<4.9.18|>=4.10,<4.11.7|>=4.13,<4.13.3|= 4.10.0",
                 "contao/listing-bundle": ">=4,<4.4.8",
                 "contao/managed-edition": "<=1.5",
-                "craftcms/cms": "<3.7.36",
+                "craftcms/cms": "<3.7.55.2|>= 4.0.0-RC1, < 4.2.1",
                 "croogo/croogo": "<3.0.7",
                 "cuyz/valinor": "<0.12",
                 "czproject/git-php": "<4.0.3",
@@ -6397,7 +6570,7 @@
                 "doctrine/mongodb-odm-bundle": ">=2,<3.0.1",
                 "doctrine/orm": ">=2,<2.4.8|>=2.5,<2.5.1|>=2.8.3,<2.8.4",
                 "dolibarr/dolibarr": "<16|= 12.0.5|>= 3.3.beta1, < 13.0.2",
-                "dompdf/dompdf": "<2",
+                "dompdf/dompdf": "<2.0.1",
                 "drupal/core": ">=7,<7.91|>=8,<9.3.19|>=9.4,<9.4.3",
                 "drupal/drupal": ">=7,<7.80|>=8,<8.9.16|>=9,<9.1.12|>=9.2,<9.2.4",
                 "dweeves/magmi": "<=0.7.24",
@@ -6409,6 +6582,8 @@
                 "enshrined/svg-sanitize": "<0.15",
                 "erusev/parsedown": "<1.7.2",
                 "ether/logs": "<3.0.4",
+                "exceedone/exment": "<4.4.3|>=5,<5.0.3",
+                "exceedone/laravel-admin": "= 3.0.0|<2.2.3",
                 "ezsystems/demobundle": ">=5.4,<5.4.6.1",
                 "ezsystems/ez-support-tools": ">=2.2,<2.2.3",
                 "ezsystems/ezdemo-ls-extension": ">=5.4,<5.4.2.1",
@@ -6428,7 +6603,7 @@
                 "facade/ignition": "<1.16.15|>=2,<2.4.2|>=2.5,<2.5.2",
                 "facturascripts/facturascripts": "<=2022.8",
                 "feehi/cms": "<=2.1.1",
-                "feehi/feehicms": "<=0.1.3",
+                "feehi/feehicms": "<=2.0.1.1",
                 "fenom/fenom": "<=2.12.1",
                 "filegator/filegator": "<7.8",
                 "firebase/php-jwt": "<2",
@@ -6441,19 +6616,20 @@
                 "fooman/tcpdf": "<6.2.22",
                 "forkcms/forkcms": "<5.11.1",
                 "fossar/tcpdf-parser": "<6.2.22",
-                "francoisjacquet/rosariosis": "<9.1",
+                "francoisjacquet/rosariosis": "<10.1",
                 "friendsofsymfony/oauth2-php": "<1.3",
                 "friendsofsymfony/rest-bundle": ">=1.2,<1.2.2",
                 "friendsofsymfony/user-bundle": ">=1.2,<1.3.5",
                 "friendsoftypo3/mediace": ">=7.6.2,<7.6.5",
                 "froala/wysiwyg-editor": "<3.2.7",
-                "froxlor/froxlor": "<=0.10.22",
+                "froxlor/froxlor": "<0.10.38",
                 "fuel/core": "<1.8.1",
                 "gaoming13/wechat-php-sdk": "<=1.10.2",
                 "genix/cms": "<=1.1.11",
                 "getgrav/grav": "<1.7.34",
-                "getkirby/cms": "<3.5.8",
+                "getkirby/cms": "<3.5.8.1|>=3.6,<3.6.6.1|>=3.7,<3.7.4",
                 "getkirby/panel": "<2.5.14",
+                "getkirby/starterkit": "<=3.7.0.2",
                 "gilacms/gila": "<=1.11.4",
                 "globalpayments/php-sdk": "<2",
                 "google/protobuf": "<3.15",
@@ -6511,7 +6687,7 @@
                 "league/commonmark": "<0.18.3",
                 "league/flysystem": "<1.1.4|>=2,<2.1.1",
                 "lexik/jwt-authentication-bundle": "<2.10.7|>=2.11,<2.11.3",
-                "librenms/librenms": "<22.4",
+                "librenms/librenms": "<=22.8",
                 "limesurvey/limesurvey": "<3.27.19",
                 "livehelperchat/livehelperchat": "<=3.91",
                 "livewire/livewire": ">2.2.4,<2.2.6",
@@ -6526,8 +6702,11 @@
                 "matyhtf/framework": "<3.0.6",
                 "mautic/core": "<4.3|= 2.13.1",
                 "mediawiki/core": ">=1.27,<1.27.6|>=1.29,<1.29.3|>=1.30,<1.30.2|>=1.31,<1.31.9|>=1.32,<1.32.6|>=1.32.99,<1.33.3|>=1.33.99,<1.34.3|>=1.34.99,<1.35",
+                "melisplatform/melis-asset-manager": "<5.0.1",
+                "melisplatform/melis-cms": "<5.0.1",
+                "melisplatform/melis-front": "<5.0.1",
                 "mezzio/mezzio-swoole": "<3.7|>=4,<4.3",
-                "microweber/microweber": "<1.3.1",
+                "microweber/microweber": "<=1.3.1",
                 "miniorange/miniorange-saml": "<1.4.3",
                 "mittwald/typo3_forum": "<1.2.1",
                 "modx/revolution": "<= 2.8.3-pl|<2.8",
@@ -6546,6 +6725,7 @@
                 "nette/application": ">=2,<2.0.19|>=2.1,<2.1.13|>=2.2,<2.2.10|>=2.3,<2.3.14|>=2.4,<2.4.16|>=3,<3.0.6",
                 "nette/nette": ">=2,<2.0.19|>=2.1,<2.1.13",
                 "nilsteampassnet/teampass": "<=2.1.27.36",
+                "notrinos/notrinos-erp": "<=0.7",
                 "noumo/easyii": "<=0.9",
                 "nukeviet/nukeviet": "<4.5.2",
                 "nystudio107/craft-seomatic": "<3.4.12",
@@ -6554,7 +6734,7 @@
                 "october/cms": "= 1.1.1|= 1.0.471|= 1.0.469|>=1.0.319,<1.0.469",
                 "october/october": ">=1.0.319,<1.0.466|>=2.1,<2.1.12",
                 "october/rain": "<1.0.472|>=1.1,<1.1.2",
-                "october/system": "<1.0.476|>=1.1,<1.1.12|>=2,<2.2.15",
+                "october/system": "<2.2.34|>=3,<3.0.66",
                 "onelogin/php-saml": "<2.10.4",
                 "oneup/uploader-bundle": "<1.9.3|>=2,<2.1.5",
                 "open-web-analytics/open-web-analytics": "<1.7.4",
@@ -6589,16 +6769,16 @@
                 "phpwhois/phpwhois": "<=4.2.5",
                 "phpxmlrpc/extras": "<0.6.1",
                 "pimcore/data-hub": "<1.2.4",
-                "pimcore/pimcore": "<10.4.4",
+                "pimcore/pimcore": "<=10.5.6",
                 "pocketmine/bedrock-protocol": "<8.0.2",
                 "pocketmine/pocketmine-mp": "<4.7.2|>= 4.0.0-BETA5, < 4.4.2",
                 "pressbooks/pressbooks": "<5.18",
                 "prestashop/autoupgrade": ">=4,<4.10.1",
                 "prestashop/blockwishlist": ">=2,<2.1.1",
-                "prestashop/contactform": ">1.0.1,<4.3",
+                "prestashop/contactform": ">=1.0.1,<4.3",
                 "prestashop/gamification": "<2.3.2",
                 "prestashop/prestashop": ">=1.6.0.10,<1.7.8.7",
-                "prestashop/productcomments": ">=4,<4.2.1",
+                "prestashop/productcomments": "<5.0.2",
                 "prestashop/ps_emailsubscription": "<2.6.1",
                 "prestashop/ps_facetedsearch": "<3.4.1",
                 "prestashop/ps_linklist": "<3.1",
@@ -6610,6 +6790,8 @@
                 "pusher/pusher-php-server": "<2.2.1",
                 "pwweb/laravel-core": "<=0.3.6-beta",
                 "rainlab/debugbar-plugin": "<3.1",
+                "rankmath/seo-by-rank-math": "<=1.0.95",
+                "react/http": ">=0.7,<1.7",
                 "remdex/livehelperchat": "<3.99",
                 "rmccue/requests": ">=1.6,<1.8",
                 "robrichards/xmlseclibs": "<3.0.4",
@@ -6624,7 +6806,7 @@
                 "shopware/core": "<=6.4.9",
                 "shopware/platform": "<=6.4.9",
                 "shopware/production": "<=6.3.5.2",
-                "shopware/shopware": "<=5.7.13",
+                "shopware/shopware": "<=5.7.14",
                 "shopware/storefront": "<=6.4.8.1",
                 "shopxo/shopxo": "<2.2.6",
                 "showdoc/showdoc": "<2.10.4",
@@ -6648,8 +6830,8 @@
                 "simplesamlphp/simplesamlphp-module-infocard": "<1.0.1",
                 "simplito/elliptic-php": "<1.0.6",
                 "slim/slim": "<2.6",
-                "smarty/smarty": "<3.1.45|>=4,<4.1.1",
-                "snipe/snipe-it": "<=6.0.2|>= 6.0.0-RC-1, <= 6.0.0-RC-5",
+                "smarty/smarty": "<3.1.47|>=4,<4.2.1",
+                "snipe/snipe-it": "<6.0.11|>= 6.0.0-RC-1, <= 6.0.0-RC-5",
                 "socalnick/scn-social-auth": "<1.15.2",
                 "socialiteproviders/steam": "<1.1",
                 "spipu/html2pdf": "<5.2.4",
@@ -6711,23 +6893,24 @@
                 "thinkcmf/thinkcmf": "<=5.1.7",
                 "tinymce/tinymce": "<5.10",
                 "titon/framework": ">=0,<9.9.99",
-                "topthink/framework": "<=6.0.12",
+                "topthink/framework": "<=6.0.13",
                 "topthink/think": "<=6.0.9",
                 "topthink/thinkphp": "<=3.2.3",
                 "tribalsystems/zenario": "<9.2.55826",
                 "truckersmp/phpwhois": "<=4.3.1",
-                "twig/twig": "<1.38|>=2,<2.14.11|>=3,<3.3.8",
-                "typo3/cms": ">=6.2,<6.2.30|>=7,<7.6.32|>=8,<8.7.38|>=9,<9.5.29|>=10,<10.4.29|>=11,<11.5.11",
+                "twig/twig": "<1.44.7|>=2,<2.15.3|>=3,<3.4.3",
+                "typo3/cms": ">=6.2,<6.2.30|>=7,<7.6.32|>=8,<8.7.38|>=9,<9.5.29|>=10,<10.4.32|>=11,<11.5.16",
                 "typo3/cms-backend": ">=7,<=7.6.50|>=8,<=8.7.39|>=9,<=9.5.24|>=10,<=10.4.13|>=11,<=11.1",
-                "typo3/cms-core": ">=6.2,<=6.2.56|>=7,<7.6.57|>=8,<8.7.47|>=9,<9.5.35|>=10,<10.4.29|>=11,<11.5.11",
+                "typo3/cms-core": ">=6.2,<=6.2.56|>=7,<7.6.58|>=8,<8.7.48|>=9,<9.5.37|>=10,<10.4.32|>=11,<11.5.16",
                 "typo3/cms-form": ">=8,<=8.7.39|>=9,<=9.5.24|>=10,<=10.4.13|>=11,<=11.1",
                 "typo3/flow": ">=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1|>=2.3,<2.3.16|>=3,<3.0.12|>=3.1,<3.1.10|>=3.2,<3.2.13|>=3.3,<3.3.13|>=4,<4.0.6",
+                "typo3/html-sanitizer": ">=1,<1.0.7|>=2,<2.0.16",
                 "typo3/neos": ">=1.1,<1.1.3|>=1.2,<1.2.13|>=2,<2.0.4|>=2.3,<2.3.99|>=3,<3.0.20|>=3.1,<3.1.18|>=3.2,<3.2.14|>=3.3,<3.3.23|>=4,<4.0.17|>=4.1,<4.1.16|>=4.2,<4.2.12|>=4.3,<4.3.3",
                 "typo3/phar-stream-wrapper": ">=1,<2.1.1|>=3,<3.1.1",
                 "typo3/swiftmailer": ">=4.1,<4.1.99|>=5.4,<5.4.5",
                 "typo3fluid/fluid": ">=2,<2.0.8|>=2.1,<2.1.7|>=2.2,<2.2.4|>=2.3,<2.3.7|>=2.4,<2.4.4|>=2.5,<2.5.11|>=2.6,<2.6.10",
                 "ua-parser/uap-php": "<3.8",
-                "unisharp/laravel-filemanager": "<=2.3",
+                "unisharp/laravel-filemanager": "<=2.5.1",
                 "userfrosting/userfrosting": ">=0.3.1,<4.6.3",
                 "usmanhalalit/pixie": "<1.0.3|>=2,<2.0.2",
                 "vanilla/safecurl": "<0.9.2",
@@ -6746,7 +6929,7 @@
                 "wpanel/wpanel4-cms": "<=4.3.1",
                 "wwbn/avideo": "<=11.6",
                 "yeswiki/yeswiki": "<4.1",
-                "yetiforce/yetiforce-crm": "<6.4",
+                "yetiforce/yetiforce-crm": "<=6.4",
                 "yidashi/yii2cmf": "<=2",
                 "yii2mod/yii2-cms": "<1.9.2",
                 "yiisoft/yii": ">=1.1.14,<1.1.15",
@@ -6820,7 +7003,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-22T17:06:07+00:00"
+            "time": "2022-10-13T20:04:41+00:00"
         },
         {
             "name": "sensio/framework-extra-bundle",
@@ -8364,16 +8547,16 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "v4.4.44",
+            "version": "v4.4.47",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/symfony.git",
-                "reference": "4a61fa7d89245ac0e8a8b8a44e05f4abd8f8f233"
+                "reference": "988b385dc014c7d617b89ed021f10bc6a1422bb1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/symfony/zipball/4a61fa7d89245ac0e8a8b8a44e05f4abd8f8f233",
-                "reference": "4a61fa7d89245ac0e8a8b8a44e05f4abd8f8f233",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/988b385dc014c7d617b89ed021f10bc6a1422bb1",
+                "reference": "988b385dc014c7d617b89ed021f10bc6a1422bb1",
                 "shasum": ""
             },
             "require": {
@@ -8551,7 +8734,7 @@
             ],
             "support": {
                 "issues": "https://github.com/symfony/symfony/issues",
-                "source": "https://github.com/symfony/symfony/tree/v4.4.44"
+                "source": "https://github.com/symfony/symfony/tree/v4.4.47"
             },
             "funding": [
                 {
@@ -8567,7 +8750,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-07-29T12:23:53+00:00"
+            "time": "2022-10-12T07:06:00+00:00"
         },
         {
             "name": "tecnickcom/tcpdf",
@@ -8643,16 +8826,16 @@
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
-            "version": "2.2.4",
+            "version": "2.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tijsverkoyen/CssToInlineStyles.git",
-                "reference": "da444caae6aca7a19c0c140f68c6182e337d5b1c"
+                "reference": "4348a3a06651827a27d989ad1d13efec6bb49b19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tijsverkoyen/CssToInlineStyles/zipball/da444caae6aca7a19c0c140f68c6182e337d5b1c",
-                "reference": "da444caae6aca7a19c0c140f68c6182e337d5b1c",
+                "url": "https://api.github.com/repos/tijsverkoyen/CssToInlineStyles/zipball/4348a3a06651827a27d989ad1d13efec6bb49b19",
+                "reference": "4348a3a06651827a27d989ad1d13efec6bb49b19",
                 "shasum": ""
             },
             "require": {
@@ -8690,9 +8873,9 @@
             "homepage": "https://github.com/tijsverkoyen/CssToInlineStyles",
             "support": {
                 "issues": "https://github.com/tijsverkoyen/CssToInlineStyles/issues",
-                "source": "https://github.com/tijsverkoyen/CssToInlineStyles/tree/2.2.4"
+                "source": "https://github.com/tijsverkoyen/CssToInlineStyles/tree/2.2.5"
             },
-            "time": "2021-12-08T09:12:39+00:00"
+            "time": "2022-09-12T13:28:28+00:00"
         },
         {
             "name": "tubalmartin/cssmin",
@@ -8882,9 +9065,9 @@
     ],
     "minimum-stability": "dev",
     "stability-flags": {
+        "ezyang/htmlpurifier": 20,
         "prestashop/prestashop": 20,
-        "roave/security-advisories": 20,
-        "ezyang/htmlpurifier": 20
+        "roave/security-advisories": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -1,7 +1,7 @@
 version: "3"
 services:
   btcpayserver:
-    image: btcpayserver/btcpayserver:1.5.0
+    image: btcpayserver/btcpayserver:1.6.12
     expose:
       - "49392"
     environment:
@@ -23,7 +23,7 @@ services:
 
   bitcoind:
     container_name: btcpayserver_bitcoind
-    image: btcpayserver/bitcoin:22.0-1
+    image: btcpayserver/bitcoin:23.0
     environment:
       BITCOIN_NETWORK: regtest
       BITCOIN_WALLETDIR: "/walletdata"
@@ -45,7 +45,7 @@ services:
       - "bitcoin_wallet_datadir:/walletdata"
 
   nbxplorer:
-    image: nicolasdorier/nbxplorer:2.3.20
+    image: nicolasdorier/nbxplorer:2.3.39
     expose:
       - "32838"
     environment:
@@ -64,7 +64,7 @@ services:
       - postgres
 
   postgres:
-    image: btcpayserver/postgres:13.6
+    image: btcpayserver/postgres:13.7
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
     volumes:

--- a/modules/btcpay/composer.json
+++ b/modules/btcpay/composer.json
@@ -24,7 +24,7 @@
     "ext-intl": "*",
     "ext-json": "*",
     "ext-mbstring": "*",
-    "btcpayserver/btcpayserver-greenfield-php": "^1.3.5",
+    "btcpayserver/btcpayserver-greenfield-php": "^1.3.6",
     "stechstudio/backoff": "^1.2"
   },
   "require-dev": {

--- a/modules/btcpay/composer.lock
+++ b/modules/btcpay/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "94541497d885de521099720b4f7cf7f7",
+    "content-hash": "99ecc8c151ef840dea882afd6e672147",
     "packages": [
         {
             "name": "btcpayserver/btcpayserver-greenfield-php",
-            "version": "v1.3.5",
+            "version": "v1.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/btcpayserver/btcpayserver-greenfield-php.git",
-                "reference": "3e39b11749056c767eef3799c12e1064f06f4653"
+                "reference": "cc9ab93a8ecda8a8158b717f11ff37dfa5ab8962"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/btcpayserver/btcpayserver-greenfield-php/zipball/3e39b11749056c767eef3799c12e1064f06f4653",
-                "reference": "3e39b11749056c767eef3799c12e1064f06f4653",
+                "url": "https://api.github.com/repos/btcpayserver/btcpayserver-greenfield-php/zipball/cc9ab93a8ecda8a8158b717f11ff37dfa5ab8962",
+                "reference": "cc9ab93a8ecda8a8158b717f11ff37dfa5ab8962",
                 "shasum": ""
             },
             "require": {
@@ -55,9 +55,9 @@
             "description": "BTCPay Server Greenfield API PHP client library.",
             "support": {
                 "issues": "https://github.com/btcpayserver/btcpayserver-greenfield-php/issues",
-                "source": "https://github.com/btcpayserver/btcpayserver-greenfield-php/tree/v1.3.5"
+                "source": "https://github.com/btcpayserver/btcpayserver-greenfield-php/tree/v1.3.6"
             },
-            "time": "2022-08-17T22:08:29+00:00"
+            "time": "2022-09-12T21:30:25+00:00"
         },
         {
             "name": "stechstudio/backoff",

--- a/modules/btcpay/config.xml
+++ b/modules/btcpay/config.xml
@@ -2,7 +2,7 @@
 <module>
   <name>btcpay</name>
   <displayName><![CDATA[BTCPay]]></displayName>
-  <version><![CDATA[5.1.7]]></version>
+  <version><![CDATA[5.2.0]]></version>
   <description><![CDATA[Accept crypto payments via BTCPay Server.]]></description>
   <author><![CDATA[BTCPayServer]]></author>
   <tab><![CDATA[payments_gateways]]></tab>

--- a/modules/btcpay/config/routes.yml
+++ b/modules/btcpay/config/routes.yml
@@ -9,7 +9,7 @@ admin_btcpay_configure:
 
 admin_btcpay_configure_process:
   path: /btcpay/configure
-  methods: [POST]
+  methods: [GET, POST]
   defaults:
     _controller: 'BTCPay\Controller\Admin\Improve\Payment\ConfigureController::editProcessAction'
     _legacy_controller: AdminConfigureBTCPay
@@ -22,3 +22,4 @@ admin_btcpay_validate:
     _controller: 'BTCPay\Controller\Admin\Improve\Payment\ConfigureController::validateAction'
     _legacy_controller: AdminConfigureBTCPay
     _disable_module_prefix: true
+

--- a/modules/btcpay/config/services.yml
+++ b/modules/btcpay/config/services.yml
@@ -15,6 +15,7 @@ services:
     class: BTCPay\Controller\Admin\Improve\Payment\ConfigureController
     arguments:
       - '@prestashop.module.btcpay'
+      - '@prestashop.module.btcpay.form_handler'
       - '@validator'
 
   # BTCPay form data provider

--- a/modules/btcpay/src/Constants.php
+++ b/modules/btcpay/src/Constants.php
@@ -8,7 +8,7 @@ class Constants
 {
 	// Version information
 	public const MINIMUM_BTCPAY_VERSION = '1.3.0';
-	public const MINIMUM_PS_VERSION     = '1.7.7';
+	public const MINIMUM_PS_VERSION     = '1.7.8';
 	public const MINIMUM_PHP_VERSION    = '7.3.0';
 
 	// BTCPay Server webhook header

--- a/modules/btcpay/src/Controller/Admin/Improve/Payment/ConfigureController.php
+++ b/modules/btcpay/src/Controller/Admin/Improve/Payment/ConfigureController.php
@@ -11,6 +11,7 @@ use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\ModuleActivated;
+use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -27,15 +28,21 @@ class ConfigureController extends FrameworkBundleAdminController
 	private $module;
 
 	/**
+	 * @var FormHandlerInterface
+	 */
+	private $formHandler;
+
+	/**
 	 * @var ValidatorInterface
 	 */
 	private $validator;
 
-	public function __construct(\BTCPay $module, ValidatorInterface $validator)
+	public function __construct(\BTCPay $module, FormHandlerInterface $formHandler, ValidatorInterface $validator)
 	{
 		parent::__construct();
 
 		$this->module = $module;
+		$this->formHandler = $formHandler;
 		$this->validator = $validator;
 	}
 
@@ -46,23 +53,34 @@ class ConfigureController extends FrameworkBundleAdminController
 	 */
 	public function editAction(Request $request): Response
 	{
-		if ($this->isInvalidApiKey()) {
+		// Build the client
+		$client = Client::createFromConfiguration($this->configuration);
+
+		// Create the authorization URL (without redirect)
+		$authorizeUrl = ApiKey::getAuthorizeUrl($this->configuration->get(Constants::CONFIGURATION_BTCPAY_HOST), Constants::BTCPAY_PERMISSIONS, $this->module->name, true, true, null, $this->module->name);
+
+		if (false === $client->isValid()) {
 			return $this->render('@Modules/btcpay/views/templates/admin/configure.html.twig', [
 				'form'          => $this->get('prestashop.module.btcpay.form_handler')->getForm()->createView(),
 				'help_link'     => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
 				'moduleVersion' => $this->module->version,
+				'authorizeUrl'  => $authorizeUrl,
 				'invalidApiKey' => true,
 				'enableSidebar' => true,
 			]);
 		}
+
+		// Ensure we always have a webhook
+		$client->webhook()->ensureWebhook($this->configuration->get(Constants::CONFIGURATION_BTCPAY_STORE_ID));
 
 		return $this->render('@Modules/btcpay/views/templates/admin/configure.html.twig', [
 			'form'          => $this->get('prestashop.module.btcpay.form_handler')->getForm()->createView(),
 			'help_link'     => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
 			'storeId'       => $this->configuration->get(Constants::CONFIGURATION_BTCPAY_STORE_ID),
 			'webhookId'     => $this->configuration->get(Constants::CONFIGURATION_BTCPAY_WEBHOOK_ID),
-			'client'        => Client::createFromConfiguration($this->configuration),
 			'moduleVersion' => $this->module->version,
+			'authorizeUrl'  => $authorizeUrl,
+			'client'        => $client,
 			'enableSidebar' => true,
 		]);
 	}
@@ -76,19 +94,23 @@ class ConfigureController extends FrameworkBundleAdminController
 	 */
 	public function editProcessAction(Request $request): Response
 	{
-		/** @var FormHandlerInterface $formHandler */
-		$formHandler = $this->get('prestashop.module.btcpay.form_handler');
+		// Get current configuration, before processing everything
+		$currentConfiguration = Configuration::create($this->configuration);
 
-		$form = $formHandler->getForm();
+		$form = $this->formHandler->getForm();
 		$form->handleRequest($request);
 
 		// Just show the boring configuration field on no submit/invalid form
 		if (!$form->isSubmitted() || !$form->isValid()) {
+			// Create the authorization URL (without redirect)
+			$authorizeUrl = ApiKey::getAuthorizeUrl($this->configuration->get(Constants::CONFIGURATION_BTCPAY_HOST), Constants::BTCPAY_PERMISSIONS, $this->module->name, true, true, null, $this->module->name);
+
 			return $this->render('@Modules/btcpay/views/templates/admin/configure.html.twig', [
 				'form'          => $form->createView(),
 				'help_link'     => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
-				'invalidApiKey' => $this->isInvalidApiKey(),
+				'invalidApiKey' => false === Client::createFromConfiguration($this->configuration)->isValid(),
 				'moduleVersion' => $this->module->version,
+				'authorizeUrl'  => $authorizeUrl,
 				'enableSidebar' => true,
 			]);
 		}
@@ -97,44 +119,46 @@ class ConfigureController extends FrameworkBundleAdminController
 		$configuration = $form->getData()['btcpay'];
 
 		// If there are errors in the form, error out here
-		if (0 !== \count($saveErrors = $formHandler->save($form->getData()))) {
+		if (0 !== \count($saveErrors = $this->formHandler->save($form->getData()))) {
 			$this->flashErrors($saveErrors);
 
 			return $this->redirectToRoute('admin_btcpay_configure');
 		}
 
-		// Get the store name and redirect URL
-		$storeName = $this->getContext()->shop->name;
-		$redirectUrl = $request->getSchemeAndHttpHost() . $this->getAdminLink('btcpay', ['route' => 'admin_btcpay_validate'], true);
+		// If the configuration is the same, just stop
+		if ($configuration->equals($currentConfiguration)) {
+			$this->addFlash('success', 'BTCPay Server Plugin: Settings have not changed.');
 
-		// If there is no apiKey, redirect no matter what
-		if (empty($apiKey = $this->configuration->get(Constants::CONFIGURATION_BTCPAY_API_KEY))) {
-			return $this->redirect(ApiKey::getAuthorizeUrl($configuration->getUrl(), Constants::BTCPAY_PERMISSIONS, $storeName, true, true, $redirectUrl, $storeName));
+			return $this->redirectToRoute('admin_btcpay_configure');
 		}
 
-		// If we have an apiKey, check if it's valid by fetching the storeId
-		try {
-			$client = new Client($configuration->getUrl(), $apiKey);
-
-			// If we don't have a store ID, abort right away
-			if (null === ($storeID = $this->configuration->get(Constants::CONFIGURATION_BTCPAY_STORE_ID))) {
-				return $this->redirect(ApiKey::getAuthorizeUrl($configuration->getUrl(), Constants::BTCPAY_PERMISSIONS, $storeName, true, true, $redirectUrl, $storeName));
+		// If we are just removing the API key, do that and return
+		if (null === $configuration->getApiKey() && !empty($currentConfiguration->getApiKey())) {
+			// Remove the current webhook to prevent issues in the future
+			if (false === (new Client($this->configuration->get(Constants::CONFIGURATION_BTCPAY_HOST), $currentConfiguration->getApiKey()))->webhook()->removeCurrent()) {
+				$this->addFlash('error', 'BTCPay Server Plugin: Could not remove webhook from the server. Please double check it is actually gone.');
 			}
 
-			// Ensure we have a webhook
-			$client->webhook()->ensureWebhook($storeID);
-		} catch (\Throwable $e) {
-			// Reset BTCPay details
 			$this->configuration->set(Constants::CONFIGURATION_BTCPAY_API_KEY, null);
+			$this->configuration->set(Constants::CONFIGURATION_BTCPAY_STORE_ID, null);
 			$this->configuration->set(Constants::CONFIGURATION_BTCPAY_WEBHOOK_ID, null);
 			$this->configuration->set(Constants::CONFIGURATION_BTCPAY_WEBHOOK_SECRET, null);
 
-			// Redirect away to get proper details
-			return $this->redirect(ApiKey::getAuthorizeUrl($configuration->getUrl(), Constants::BTCPAY_PERMISSIONS, $storeName, true, true, $redirectUrl, $storeName));
+			$this->addFlash('success', 'BTCPay Server plugin: API key has been removed');
+
+			return $this->redirectToRoute('admin_btcpay_configure');
 		}
 
-		// Return home
-		return $this->redirectToRoute('admin_btcpay_configure');
+		// Before processing anything further, make sure any webhook that exists is removed
+		(new Client($currentConfiguration->getHost(), $currentConfiguration->getApiKey()))->webhook()->removeCurrent();
+
+		// If an API key is set, use that
+		if (null !== $configuration->getApiKey()) {
+			return $this->processApiKey($configuration);
+		}
+
+		// If nothing has been set, redirect to the host
+		return $this->processRedirect($request, $configuration);
 	}
 
 	/**
@@ -146,7 +170,7 @@ class ConfigureController extends FrameworkBundleAdminController
 	{
 		// If we received an empty post we probably hit the PrestaShop security check
 		if (empty($request->request->all())) {
-			$this->addFlash('error', 'Did not receive data from BTCPay Server. If you received an <strong>Invalid Token</strong> page, make sure to properly setup PrestaShop and BTCPay Server (publicly accessible and HTTPS enabled). Please try again once done.');
+			$this->addFlash('error', 'Did not receive data from BTCPay Server. If you received an <strong>Invalid Token</strong> page, make sure to properly setup PrestaShop and BTCPay Server (publicly accessible and HTTPS enabled). Please try again once done or use the API key option.');
 
 			return $this->redirectToRoute('admin_btcpay_configure');
 		}
@@ -185,7 +209,7 @@ class ConfigureController extends FrameworkBundleAdminController
 			// Ensure we have a webhook
 			$client->webhook()->ensureWebhook($storeId);
 		} catch (\Throwable $exception) {
-			$this->addFlash('error', \sprintf('BTCPay plugin: %s', $exception->getMessage()));
+			$this->addFlash('error', \sprintf('BTCPay Server plugin: %s', $exception->getMessage()));
 			\PrestaShopLogger::addLog('[ERROR] An error occurred during setup ' . \print_r($exception, true));
 
 			return $this->redirectToRoute('admin_btcpay_configure');
@@ -195,19 +219,114 @@ class ConfigureController extends FrameworkBundleAdminController
 		$this->configuration->set(Constants::CONFIGURATION_BTCPAY_API_KEY, $validateRequest->getApiKey());
 		$this->configuration->set(Constants::CONFIGURATION_BTCPAY_STORE_ID, $storeId);
 
-		$this->addFlash('success', 'BTCPay plugin: Linked!');
+		$this->addFlash('success', 'BTCPay Server plugin: Your store and server have been linked!');
 
 		return $this->redirectToRoute('admin_btcpay_configure');
 	}
 
-	private function isInvalidApiKey(): bool
+	/**
+	 * @throws \Exception
+	 */
+	private function processApiKey(Configuration $configuration): RedirectResponse
 	{
+		// Build the client
+		$client = new Client($configuration->getHost(), $configuration->getApiKey());
+
 		try {
-			Client::createFromConfiguration($this->configuration)->server()->getInfo();
-		} catch (\Throwable $e) {
-			return true;
+			// Validate created API key and return any errors we encounter
+			$validateKey = new ValidateApiKey(new ParameterBag($client->apiKey()->getCurrent()->getData()));
+			if (0 !== \count($errors = $this->validator->validate($validateKey))) {
+				foreach ($errors as $error) {
+					$this->addFlash('error', $error->getMessage());
+				}
+
+				return $this->redirectToRoute('admin_btcpay_configure');
+			}
+
+			// Get the store ID
+			$storeId = $validateKey->getStoreID();
+
+			// Ensure we have a valid BTCPay Server version
+			if (null !== ($info = $client->server()->getInfo()) && \version_compare($info->getVersion(), Constants::MINIMUM_BTCPAY_VERSION, '<')) {
+				$this->addFlash('error', \sprintf('BTCPay server version is too low. Expected %s or higher, received %s.', Constants::MINIMUM_BTCPAY_VERSION, $info->getVersion()));
+
+				return $this->redirectToRoute('admin_btcpay_configure');
+			}
+
+			// Ensure we have a payment methods setup
+			if (empty($client->payment()->getPaymentMethods($storeId))) {
+				$this->addFlash('error', \sprintf("This plugin expects a payment method to have been setup for store '%s'.", $client->store()->getStore($storeId)->offsetGet('name')));
+
+				return $this->redirectToRoute('admin_btcpay_configure');
+			}
+
+			// Save the new store ID
+			$this->configuration->set(Constants::CONFIGURATION_BTCPAY_STORE_ID, $storeId);
+
+			// Ensure we have a webhook
+			$client->webhook()->ensureWebhook($storeId);
+		} catch (\Throwable $exception) {
+			$this->addFlash('error', \sprintf('BTCPay Server plugin: %s', $exception->getMessage()));
+			\PrestaShopLogger::addLog('[ERROR] An error occurred during setup ' . \print_r($exception, true));
+
+			// Ensure nothing is saved
+			$this->configuration->set(Constants::CONFIGURATION_BTCPAY_API_KEY, null);
+			$this->configuration->set(Constants::CONFIGURATION_BTCPAY_STORE_ID, null);
+			$this->configuration->set(Constants::CONFIGURATION_BTCPAY_WEBHOOK_ID, null);
+			$this->configuration->set(Constants::CONFIGURATION_BTCPAY_WEBHOOK_SECRET, null);
+
+			return $this->redirectToRoute('admin_btcpay_configure');
 		}
 
-		return false;
+		// Store the API key and store ID we received
+		$this->configuration->set(Constants::CONFIGURATION_BTCPAY_API_KEY, $validateKey->getApiKey());
+		$this->configuration->set(Constants::CONFIGURATION_BTCPAY_STORE_ID, $storeId);
+
+		$this->addFlash('success', 'BTCPay Server plugin: Your store and server have been linked!');
+
+		// Return home
+		return $this->redirectToRoute('admin_btcpay_configure');
+	}
+
+	/**
+	 * @throws \Exception
+	 */
+	private function processRedirect(Request $request, Configuration $configuration): RedirectResponse
+	{
+		// Get the store name and build the redirect URL
+		$storeName = $this->getContext()->shop->name;
+		$redirectUrl = $request->getSchemeAndHttpHost() . $this->getAdminLink('btcpay', ['route' => 'admin_btcpay_validate'], true);
+
+		// Create the authorization URL (with redirect)
+		$authorizeUrl = ApiKey::getAuthorizeUrl($configuration->getHost(), Constants::BTCPAY_PERMISSIONS, $storeName, true, true, $redirectUrl, $storeName);
+
+		// If there is no API key, redirect no matter what
+		if (empty($apiKey = $this->configuration->get(Constants::CONFIGURATION_BTCPAY_API_KEY))) {
+			return $this->redirect($authorizeUrl);
+		}
+
+		// If we have an apiKey, check if it's valid by fetching the storeId
+		try {
+			$client = new Client($configuration->getHost(), $apiKey);
+
+			// If we don't have a store ID, abort right away
+			if (null === ($storeID = $this->configuration->get(Constants::CONFIGURATION_BTCPAY_STORE_ID))) {
+				return $this->redirect($authorizeUrl);
+			}
+
+			// Ensure we have a webhook
+			$client->webhook()->ensureWebhook($storeID);
+		} catch (\Throwable $e) {
+			// Reset BTCPay details
+			$this->configuration->set(Constants::CONFIGURATION_BTCPAY_API_KEY, null);
+			$this->configuration->set(Constants::CONFIGURATION_BTCPAY_WEBHOOK_ID, null);
+			$this->configuration->set(Constants::CONFIGURATION_BTCPAY_WEBHOOK_SECRET, null);
+
+			// Redirect away to get proper details
+			return $this->redirect($authorizeUrl);
+		}
+
+		// Return home
+		return $this->redirectToRoute('admin_btcpay_configure');
 	}
 }

--- a/modules/btcpay/src/Form/ConfigureFormDataProvider.php
+++ b/modules/btcpay/src/Form/ConfigureFormDataProvider.php
@@ -4,7 +4,6 @@ namespace BTCPay\Form;
 
 use BTCPay\Constants;
 use BTCPay\Form\Data\Configuration;
-use BTCPayServer\Client\InvoiceCheckoutOptions;
 use PrestaShop\PrestaShop\Adapter\Configuration as PrestaShopConfiguration;
 use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
 
@@ -25,14 +24,7 @@ class ConfigureFormDataProvider implements FormDataProviderInterface
 	 */
 	public function getData(): array
 	{
-		$configuration = new Configuration(
-			$this->configuration->get(Constants::CONFIGURATION_BTCPAY_HOST, Constants::CONFIGURATION_DEFAULT_HOST),
-			$this->configuration->get(Constants::CONFIGURATION_SPEED_MODE, InvoiceCheckoutOptions::SPEED_MEDIUM),
-			$this->configuration->get(Constants::CONFIGURATION_ORDER_MODE, Constants::ORDER_MODE_BEFORE),
-			$this->configuration->get(Constants::CONFIGURATION_SHARE_METADATA, false),
-		);
-
-		return ['btcpay' => $configuration];
+		return ['btcpay' => Configuration::create($this->configuration)];
 	}
 
 	/**
@@ -43,10 +35,25 @@ class ConfigureFormDataProvider implements FormDataProviderInterface
 		/** @var Configuration $configuration */
 		$configuration = $data['btcpay'];
 
-		$this->configuration->set(Constants::CONFIGURATION_BTCPAY_HOST, \rtrim(\trim($configuration->getUrl()), '/\\'));
-		$this->configuration->set(Constants::CONFIGURATION_SPEED_MODE, $configuration->getSpeed());
-		$this->configuration->set(Constants::CONFIGURATION_ORDER_MODE, $configuration->getOrderMode());
-		$this->configuration->set(Constants::CONFIGURATION_SHARE_METADATA, $configuration->shareMetadata());
+		if ($this->configuration->get(Constants::CONFIGURATION_BTCPAY_HOST) !== \rtrim(\trim(($host = $configuration->getHost())), '/\\') && !empty($host)) {
+			$this->configuration->set(Constants::CONFIGURATION_BTCPAY_HOST, \rtrim(\trim($host), '/\\'));
+		}
+
+		if ($this->configuration->get(Constants::CONFIGURATION_BTCPAY_API_KEY) !== \rtrim(\trim(($apiKey = $configuration->getApiKey())), '/\\') && !empty($apiKey)) {
+			$this->configuration->set(Constants::CONFIGURATION_BTCPAY_API_KEY, \rtrim(\trim($apiKey), '/\\'));
+		}
+
+		if ($this->configuration->get(Constants::CONFIGURATION_SPEED_MODE) !== ($speedMode = $configuration->getSpeed()) && !empty($speedMode)) {
+			$this->configuration->set(Constants::CONFIGURATION_SPEED_MODE, $speedMode);
+		}
+
+		if ($this->configuration->get(Constants::CONFIGURATION_ORDER_MODE) !== ($orderMode = $configuration->getOrderMode()) && !empty($orderMode)) {
+			$this->configuration->set(Constants::CONFIGURATION_ORDER_MODE, $orderMode);
+		}
+
+		if ($this->configuration->get(Constants::CONFIGURATION_SHARE_METADATA) !== ($shareMetadata = $configuration->shareMetadata())) {
+			$this->configuration->set(Constants::CONFIGURATION_SHARE_METADATA, $shareMetadata);
+		}
 
 		// All is fine
 		return [];

--- a/modules/btcpay/src/Form/Data/Configuration.php
+++ b/modules/btcpay/src/Form/Data/Configuration.php
@@ -2,6 +2,8 @@
 
 namespace BTCPay\Form\Data;
 
+use BTCPay\Constants;
+use BTCPayServer\Client\InvoiceCheckoutOptions;
 use Symfony\Component\Validator\Constraints as Assert;
 
 class Configuration
@@ -12,7 +14,7 @@ class Configuration
 	 *
 	 * @var string|null
 	 */
-	private $url;
+	private $host;
 
 	/**
 	 * @Assert\NotBlank()
@@ -35,22 +37,51 @@ class Configuration
 	 */
 	private $shareMetadata;
 
-	public function __construct(string $url, string $speed, string $orderMode, bool $shareMetadata)
+	/**
+	 * @Assert\Type(type="alnum")
+	 *
+	 * @var string|null
+	 */
+	private $apiKey;
+
+	public function __construct(string $host, string $speed, string $orderMode, bool $shareMetadata, string $apiKey = null)
 	{
-		$this->url           = $url;
-		$this->speed         = $speed;
-		$this->orderMode     = $orderMode;
+		$this->host = $host;
+		$this->apiKey = $apiKey;
+		$this->speed = $speed;
+		$this->orderMode = $orderMode;
 		$this->shareMetadata = $shareMetadata;
 	}
 
-	public function getUrl(): ?string
+	public static function create(\PrestaShop\PrestaShop\Adapter\Configuration $configuration): self
 	{
-		return $this->url;
+		return new self(
+			$configuration->get(Constants::CONFIGURATION_BTCPAY_HOST, Constants::CONFIGURATION_DEFAULT_HOST),
+			$configuration->get(Constants::CONFIGURATION_SPEED_MODE, InvoiceCheckoutOptions::SPEED_MEDIUM),
+			$configuration->get(Constants::CONFIGURATION_ORDER_MODE, Constants::ORDER_MODE_BEFORE),
+			$configuration->get(Constants::CONFIGURATION_SHARE_METADATA, false),
+			$configuration->get(Constants::CONFIGURATION_BTCPAY_API_KEY),
+		);
 	}
 
-	public function setUrl(?string $url): void
+	public function getHost(): ?string
 	{
-		$this->url = $url;
+		return $this->host;
+	}
+
+	public function setHost(?string $host): void
+	{
+		$this->host = $host;
+	}
+
+	public function getApiKey(): ?string
+	{
+		return $this->apiKey;
+	}
+
+	public function setApiKey(?string $apiKey): void
+	{
+		$this->apiKey = $apiKey;
 	}
 
 	public function getSpeed(): string
@@ -83,10 +114,16 @@ class Configuration
 		$this->shareMetadata = $shareMetadata;
 	}
 
+	public function equals(self $configuration): bool
+	{
+		return $this->toArray() === $configuration->toArray();
+	}
+
 	public function toArray(): array
 	{
 		return [
-			'url'           => $this->url,
+			'host'          => $this->host,
+			'apiKey'        => $this->apiKey,
 			'speed'         => $this->speed,
 			'orderMode'     => $this->orderMode,
 			'shareMetadata' => $this->shareMetadata,

--- a/modules/btcpay/src/Form/Type/ConfigureType.php
+++ b/modules/btcpay/src/Form/Type/ConfigureType.php
@@ -7,6 +7,7 @@ use BTCPay\Form\Data\Configuration;
 use BTCPayServer\Client\InvoiceCheckoutOptions;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -19,7 +20,18 @@ class ConfigureType extends TranslatorAwareType
 	public function buildForm(FormBuilderInterface $builder, array $options): void
 	{
 		$builder
-			->add('url', UrlType::class, ['label' => $this->trans('BTCPay Server URL', 'Modules.Btcpay.Admin')])
+			->add('host', UrlType::class, ['label' => $this->trans('BTCPay Server URL', 'Modules.Btcpay.Admin')])
+			->add('api_key', TextType::class, [
+				'label'      => $this->trans('BTCPay Server API key', 'Modules.Btcpay.Admin'),
+				'attr'       => [
+					'placeholder' => empty($this->getConfiguration()->get(Constants::CONFIGURATION_BTCPAY_API_KEY))
+						? $this->trans('Leave blank to be redirected to your BTCPay Server for authentication', 'Modules.Btcpay.Admin')
+						: null,
+					'pattern'     => '[a-zA-Z0-9]+',
+				],
+				'required'   => false,
+				'empty_data' => null,
+			])
 			->add('speed', ChoiceType::class, [
 				'choices'    => [
 					$this->trans('Low', 'Modules.Btcpay.Admin')    => InvoiceCheckoutOptions::SPEED_LOW,
@@ -41,7 +53,7 @@ class ConfigureType extends TranslatorAwareType
 					$this->trans('Yes', 'Modules.Btcpay.Admin') => true,
 					$this->trans('No', 'Modules.Btcpay.Admin')  => false,
 				],
-				'label'   => $this->trans('Store customer data in BTCPay Server invoice', 'Modules.Btcpay.Admin'),
+				'label'   => $this->trans('Store customer data within invoice', 'Modules.Btcpay.Admin'),
 			]);
 	}
 

--- a/modules/btcpay/src/Installer/Webhook.php
+++ b/modules/btcpay/src/Installer/Webhook.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace BTCPay\Installer;
+
+use BTCPay\Server\Client;
+use PrestaShop\PrestaShop\Adapter\Configuration;
+
+class Webhook
+{
+	/**
+	 * @var Configuration
+	 */
+	private $configuration;
+
+	public function __construct()
+	{
+		$this->configuration = new Configuration();
+	}
+
+	/**
+	 * @throws \Exception
+	 */
+	public function uninstall(): array
+	{
+		// Remove the current webhook to prevent issues in the future
+		if (false === (Client::createFromConfiguration($this->configuration)->webhook()->removeCurrent())) {
+			return [
+				[
+					'key'        => 'Could not remove webhook from the server. Please double check it is actually gone.',
+					'parameters' => [],
+					'domain'     => 'Admin.Modules.Notification',
+				],
+			];
+		}
+
+		return [];
+	}
+}

--- a/modules/btcpay/src/Server/Client.php
+++ b/modules/btcpay/src/Server/Client.php
@@ -133,6 +133,17 @@ class Client extends AbstractClient
 		return $this->webhook;
 	}
 
+	public function isValid(): bool
+	{
+		try {
+			$this->server()->getInfo();
+		} catch (\Throwable $e) {
+			return false;
+		}
+
+		return true;
+	}
+
 	/**
 	 * @throws \PrestaShopDatabaseException
 	 * @throws \JsonException

--- a/modules/btcpay/src/Server/CurlAdapter.php
+++ b/modules/btcpay/src/Server/CurlAdapter.php
@@ -20,7 +20,7 @@ class CurlAdapter extends CurlClient
 
 	public function __construct()
 	{
-		$this->backoff = new Backoff(self::$defaultMaxAttempts, Backoff::$defaultStrategy, self::$defaultMaxAttempts * 10 * 1000, true);
+		$this->backoff = new Backoff(self::$defaultMaxAttempts, Backoff::$defaultStrategy, self::$defaultMaxAttempts * 5 * 1000, true);
 	}
 
 	/**

--- a/modules/btcpay/views/templates/admin/configure.html.twig
+++ b/modules/btcpay/views/templates/admin/configure.html.twig
@@ -1,21 +1,35 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div style="width: 100%; height: 125px;">
-    <div style="float: right; border: dashed 1px #666; padding: 8px;">
-      <a href="{{ form.btcpay.vars.data.url }}" target="_blank">
-        <img src="{{ asset('../modules/btcpay/views/images/prestashop-btcpay.png') }}" alt="PrestaShop & BTCPay Server"/>
-      </a>
-    </div>
-    <img src="{{ asset('../modules/btcpay/views/images/btcpay-plugin.png') }}" alt="BTCPay Server logo" style="float:left; margin-right:15px;"/>
-    <p><strong>{{ 'This module (v%version%) allows you to accept payments via BTCPay Server.'|trans({'%version%': moduleVersion}, 'Modules.Btcpay.Admin') }}</strong></p>
-    <p>{{ 'To be able to use this payment module you need to have a BTCPay Server instance, either <a href="https://docs.btcpayserver.org/Deployment/" target="_blank">self-hosted</a> or <a href="https://docs.btcpayserver.org/Deployment/ThirdPartyHosting/." target="_blank">hosted by a third-party</a>.<br/>With <a href="https://docs.btcpayserver.org/RegisterAccount" target="_blank">a registered account on the instance</a>, <a href="https://docs.btcpayserver.org/CreateStore" target="_blank">an actual store on the instance</a> and <a href="https://docs.btcpayserver.org/WalletSetup" target="_blank">a wallet connected to your store</a>.'|trans({}, 'Modules.Btcpay.Admin')|raw }}</p>
-  </div>
-
-  {{ form_start(form, {'action': url('admin_btcpay_configure_process'), 'attr': {'class': 'form', 'id': 'btcpay-form'}}) }}
   <div class="row ps17">
     <div class="col-12 col-spx-12 col-lg-10 col-md-10 offset-md-1 offset-lg-1">
       <div class="card">
+        <div class="card-header">
+          <i class="material-icons">extension</i>
+          {{ 'BTCPay Server - Prestashop module (v%version%)'|trans({'%version%': moduleVersion}, 'Modules.Btcpay.Admin') }}
+        </div>
+        <div class="card-body">
+          <div class="card-text">
+            <a href="https://btcpayserver.org/" target="_blank" rel="noopener noreferrer nofollow">
+              <img src="{{ asset('../modules/btcpay/views/images/btcpay-plugin.png') }}" class="float-left mb-2 mr-3" alt="{{ 'BTCPay Server logo'|trans({}, 'Modules.Btcpay.Admin') }}"/>
+            </a>
+          </div>
+          <div class="card-text">
+            <p>{{ 'To be able to use this payment module you need to have a BTCPay Server instance, either <a href="https://docs.btcpayserver.org/Deployment/" target="_blank" rel="noopener noreferrer nofollow">self-hosted</a> or <a href="https://docs.btcpayserver.org/Deployment/ThirdPartyHosting/." target="_blank" rel="noopener noreferrer nofollow">hosted by a third-party</a>.'|trans({}, 'Modules.Btcpay.Admin')|raw }}</p>
+          </div>
+          <div class="card-text">
+            <p>{{ 'With <a href="https://docs.btcpayserver.org/RegisterAccount" target="_blank" rel="noopener noreferrer nofollow">a registered account on the instance</a>, <a href="https://docs.btcpayserver.org/CreateStore" target="_blank" rel="noopener noreferrer nofollow">an actual store on the instance</a> and <a href="https://docs.btcpayserver.org/WalletSetup" target="_blank">a wallet connected to your store</a>.'|trans({}, 'Modules.Btcpay.Admin')|raw }}</p>
+          </div>
+          <div class="clearfix"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row ps17">
+    <div class="{% if invalidApiKey is defined %}col-5 col-spx-5 col-lg-5 col-md-5 {% else %}col-12 col-spx-12 col-lg-10 col-md-10{% endif %} offset-md-1 offset-lg-1">
+      <div class="card">
+        {{ form_start(form, {'action': url('admin_btcpay_configure_process'), 'attr': {'class': 'form', 'id': 'btcpay-form'}}) }}
         <h3 class="card-header">
           <i class="material-icons">mode_edit</i>
           {{ 'Settings'|trans({}, 'Admin.Global') }}
@@ -23,29 +37,53 @@
 
         <div class="card-block">
           <div class="card-text">
-            {{ form_row(form.btcpay.url) }}
+            {{ form_row(form.btcpay.host) }}
+            {{ form_row(form.btcpay.api_key) }}
             {{ form_row(form.btcpay.speed) }}
             {{ form_row(form.btcpay.order_mode) }}
             {{ form_row(form.btcpay.share_metadata) }}
             {{ form_rest(form) }}
-          </div>
-          <div class="card-text text-center">
-            {% if invalidApiKey is defined %}
-              <small>{{ 'Press "Connect" to get an API key from the specified host.'|trans({}, 'Modules.Btcpay.Admin') }}</small>
-            {% endif %}
           </div>
         </div>
 
         <div class="card-footer">
           <div class="d-flex justify-content-between">
             <a href="{{ getAdminLink('AdminDashboard') }}" class="btn btn-secondary">{{ 'Cancel'|trans({}, 'Admin.Actions') }}</a>
-              <button class="btn btn-primary">{% if invalidApiKey is defined  %}{{ 'Connect'|trans({}, 'Admin.Actions') }}{% else %}{{ 'Save'|trans({}, 'Admin.Actions') }}{% endif %}</button>
+            <button class="btn btn-primary" type="submit">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+          </div>
+        </div>
+        {{ form_end(form) }}
+      </div>
+    </div>
+    {% if invalidApiKey is defined %}
+      <div class="col-5 col-spx-5 col-lg-5 col-md-5">
+        <div class="card">
+          <h3 class="card-header">
+            <i class="material-icons">info_outline</i>
+            {{ 'Setup information'|trans({}, 'Admin.Global') }}
+          </h3>
+
+          <div class="card-block">
+            <div class="card-text">
+              <p>{{ 'The quickest way to get the plugin working is to set the proper <em>BTCPay Server URL</em> and press save. You will be redirected to your BTCPay Server where you will be guided through the API key creation process. Once the key is created, you\'ll be redirected back to Prestashop.'|trans({}, 'Modules.Btcpay.Admin')|raw }}</p>
+              <p>{{ 'Redirecting back from BTCPay Server sometimes fails due to PrestaShop weirdness, if it does, you can still use this plugin by copying the API key from <code>/account/apikeys</code>. and pasting it in the form.'|trans({}, 'Modules.Btcpay.Admin')|raw }}</p>
+              <hr/>
+              <p>{{ 'If preferred, you can also make an API key yourself by pressing the button below (<em>make sure your BTCPay Server URL is correct, first</em>) or by creating it at <code>/account/addapikey</code>. If you are going to make an API key yourself, make sure that it has the following permissions for a <em>singluar</em> store:'|trans({}, 'Modules.Btcpay.Admin')|raw }}</p>
+              <ul>
+                {% for permission in constant('\\BTCPay\\Constants::BTCPAY_PERMISSIONS') %}
+                  <li>{{ permission }}</li>
+                {% endfor %}
+              </ul>
+            </div>
+          </div>
+
+          <div class="card-footer text-right">
+            <a href="{{ authorizeUrl }}" class="btn btn-primary" target="_blank" rel="noopener noreferrer nofollow">{{ 'Create API key'|trans({}, 'Admin.Actions') }}</a>
           </div>
         </div>
       </div>
-    </div>
+    {% endif %}
   </div>
-  {{ form_end(form) }}
 
   <div class="row ps17">
     <div class="col-12 col-spx-12 col-lg-10 col-md-10 offset-md-1 offset-lg-1">
@@ -53,32 +91,32 @@
         {% if storeId is defined and client is defined %}
           {% set storeInfo = client.store().getStore(storeId) %}
           <div class="card">
-              <h3 class="card-header">
-                <i class="material-icons">store</i>
-                {{ 'Store Information'|trans({}, 'Admin.Actions') }}
-              </h3>
+            <h3 class="card-header">
+              <i class="material-icons">store</i>
+              {{ 'Store Information'|trans({}, 'Admin.Actions') }}
+            </h3>
 
-              <div class="card-block">
-                <div class="card-text">
-                  <dl>
-                    <dt><span class="text-muted mb-0"><strong>Linked Store Name</strong></span></dt>
-                    <dd><span class="px-1">{% if storeInfo.website is not empty %}<a href="{{ storeInfo.website }}" target="_blank">{{ storeInfo.name }}</a>{% else %}{{ storeInfo.name }}{% endif %}</span></dd>
+            <div class="card-block">
+              <div class="card-text">
+                <dl>
+                  <dt><span class="text-muted mb-0"><strong>{{ 'Linked Store Name'|trans({}, 'Modules.Btcpay.Admin') }}</strong></span></dt>
+                  <dd><span class="px-1">{% if storeInfo.website is not empty %}<a href="{{ storeInfo.website }}" target="_blank" rel="noopener noreferrer nofollow">{{ storeInfo.name }}</a>{% else %}{{ storeInfo.name }}{% endif %}</span></dd>
 
-                    <dt><span class="text-muted mb-0"><strong>Default speed policy</strong></span></dt>
-                    <dd><span class="px-1">{{ storeInfo.speedPolicy }}</span></dd>
+                  <dt><span class="text-muted mb-0"><strong>{{ 'Default speed policy'|trans({}, 'Modules.Btcpay.Admin') }}</strong></span></dt>
+                  <dd><span class="px-1">{{ storeInfo.speedPolicy }}</span></dd>
 
-                    <dt><span class="text-muted mb-0"><strong>Invoice expiration time</strong></span></dt>
-                    <dd><span class="px-1">{{ storeInfo.invoiceExpiration }} minutes</span></dd>
+                  <dt><span class="text-muted mb-0"><strong>{{ 'Invoice expiration time'|trans({}, 'Modules.Btcpay.Admin') }}</strong></span></dt>
+                  <dd><span class="px-1">{{ storeInfo.invoiceExpiration }} {{ 'minutes'|trans({}, 'Modules.BtcPay.Global') }}</span></dd>
 
-                    <dt><span class="text-muted mb-0"><strong>Invoice monitoring expiration time</strong></span></dt>
-                    <dd><span class="px-1">{{ storeInfo.monitoringExpiration }} minutes</span></dd>
+                  <dt><span class="text-muted mb-0"><strong>Invoice monitoring expiration time</strong></span></dt>
+                  <dd><span class="px-1">{{ storeInfo.monitoringExpiration }} {{ 'minutes'|trans({}, 'Modules.BtcPay.Global') }}</span></dd>
 
-                    <dt><span class="text-muted mb-0"><strong>Default currency</strong></span></dt>
-                    <dd><span class="px-1">{% if storeInfo.defaultCurrency is empty %}None{% else %}{{ storeInfo.defaultCurrency }}{% endif %}</span></dd>
-                  </dl>
-                </div>
+                  <dt><span class="text-muted mb-0"><strong>{{ 'Default currency'|trans({}, 'Modules.Btcpay.Admin') }}</strong></span></dt>
+                  <dd><span class="px-1">{% if storeInfo.defaultCurrency is empty %}{{ 'None'|trans({}, 'Modules.BtcPay.Global') }}{% else %}{{ storeInfo.defaultCurrency }}{% endif %}</span></dd>
+                </dl>
               </div>
             </div>
+          </div>
         {% endif %}
 
         {% if storeId is defined and client is defined %}
@@ -91,28 +129,33 @@
 
             <div class="card-body">
               <dl>
-                <dt><span class="text-muted mb-0"><strong>Version</strong></span></dt>
+                <dt><span class="text-muted mb-0"><strong>{{ 'Version'|trans({}, 'Modules.Btcpay.Admin') }}</strong></span></dt>
                 <dd><span class="px-1">{{ serverInfo.version }}</span></dd>
 
-                <dt><span class="text-muted mb-0"><strong>API Key</strong></span></dt>
-                <dd><span class="px-1">{{ client.apiKey().getCurrent().apiKey }}</span></dd>
-
                 {% set webhook = client.webhook().getCurrent(storeId, webhookId) %}
-                <dt><span class="text-muted mb-0"><strong>Webhook ID</strong></span></dt>
-                <dd><span class="{% if webhook.enabled %}text-success{% else %}text-warning{% endif %} px-1">{{ webhook.id }}</span></dd>
+                <dt><span class="text-muted mb-0"><strong>{{ 'Webhook ID'|trans({}, 'Modules.Btcpay.Admin') }}</strong></span></dt>
+                {% if webhook is not null %}
+                  <dd><span class="{% if webhook.enabled %}text-success{% else %}text-warning{% endif %} px-1">{{ webhook.id }}</span></dd>
+                {% endif %}
 
-                <dt><span class="text-muted mb-0"><strong>Fully synced</strong></span></dt>
-                <dd>{% if serverInfo.fullySynced %}<span class="text-success px-1">Yes</span>{% else %}<span class="text-warning px-1"><span title="The payment option won't be available until the server is synced">No</span></span>{% endif %}</dd>
+                <dt><span class="text-muted mb-0"><strong>{{ 'Node fully synced'|trans({}, 'Modules.Btcpay.Admin') }}</strong></span></dt>
+                <dd>
+                  {% if serverInfo.fullySynced %}
+                    <span class="text-success px-1">Yes</span>
+                  {% else %}
+                    <span class="text-warning px-1"><span title="The payment option won't be available until the server is synced">No</span></span>
+                  {% endif %}
+                </dd>
 
-                <dt><span class="text-muted mb-0"><strong>Payment methods</strong></span></dt>
+                <dt><span class="text-muted mb-0"><strong>{{ 'Supported payment methods'|trans({}, 'Modules.Btcpay.Front') }}</strong></span></dt>
                 <dd>
                   <ul class="list-unstyled px-1">
-                  {% for paymentMethod in client.offChain().getPaymentMethods(storeId) %}
-                    <li>{{ paymentMethod.cryptoCode }} Lightning ⚡</li>
-                  {% endfor %}
-                  {% for paymentMethod in client.onChain().getPaymentMethods(storeId) %}
-                    <li>{{ paymentMethod.cryptoCode }} On-Chain</li>
-                  {% endfor %}
+                    {% for paymentMethod in client.offChain().getPaymentMethods(storeId) %}
+                      <li>{{ paymentMethod.cryptoCode }} Lightning ⚡</li>
+                    {% endfor %}
+                    {% for paymentMethod in client.onChain().getPaymentMethods(storeId) %}
+                      <li>{{ paymentMethod.cryptoCode }} On-Chain</li>
+                    {% endfor %}
                   </ul>
                 </dd>
               </dl>

--- a/modules/btcpay/views/templates/admin/invoice_block.tpl
+++ b/modules/btcpay/views/templates/admin/invoice_block.tpl
@@ -9,7 +9,7 @@
         <div class="row">
           <div class="col-sm text-center">
             <p class="text-muted mb-0"><strong>Invoice</strong></p>
-            <a class="configure-link" href="{$server_url}/invoices/{$invoice.id}" target="_blank">{$invoice.id}</a>
+            <a class="configure-link" href="{$server_url}/invoices/{$invoice.id}" target="_blank" rel="noopener noreferrer nofollow">{$invoice.id}</a>
           </div>
 
           <div class="col-sm text-center">
@@ -78,9 +78,9 @@
                       <td>{$payment->getReceivedTimestamp()|date_format:"%Y-%m-%d %T"}</td>
                       <td>{$payment.value} {$currencyCode}</td>
                         {if $currencyCode == 'BTC'}
-                          <td><a href="https://mempool.space/tx/{$payment->getTransactionId()}" target="_blank">{$payment->getTransactionId()}</a></td>
+                          <td><a href="https://mempool.space/tx/{$payment->getTransactionId()}" target="_blank" rel="noopener noreferrer nofollow">{$payment->getTransactionId()}</a></td>
                         {else}
-                          <td><a href="https://blockchair.com/search?q={$payment->getTransactionId()}" target="_blank">{$payment->getTransactionId()}</a></td>
+                          <td><a href="https://blockchair.com/search?q={$payment->getTransactionId()}" target="_blank" rel="noopener noreferrer nofollow">{$payment->getTransactionId()}</a></td>
                         {/if}
                     </tr>
                   {/foreach}

--- a/modules/btcpay/views/templates/hooks/order_detail.tpl
+++ b/modules/btcpay/views/templates/hooks/order_detail.tpl
@@ -3,7 +3,7 @@
   <div class="row">
     <div class="col-md-4 m-1 my-2">
       <p class="text-muted mb-0"><strong>Invoice</strong></p>
-      <a class="configure-link" href="{$serverURL}/i/{$invoice.id}" target="_blank">{$invoice.id}</a>
+      <a class="configure-link" href="{$serverURL}/i/{$invoice.id}" target="_blank" rel="noopener noreferrer nofollow">{$invoice.id}</a>
     </div>
     <div class="col-md-4 m-1 my-2">
       <p class="text-muted mb-0"><strong>Status</strong></p>
@@ -61,9 +61,9 @@
             <td>{$payment->getReceivedTimestamp()|date_format:"%Y-%m-%d %T"}</td>
             <td>{$payment.value} {$currencyCode}</td>
               {if $currencyCode == 'BTC'}
-                <td><a href="https://mempool.space/tx/{$payment->getTransactionId()}" target="_blank">{$payment->getTransactionId()}</a></td>
+                <td><a href="https://mempool.space/tx/{$payment->getTransactionId()}" target="_blank" rel="noopener noreferrer nofollow">{$payment->getTransactionId()}</a></td>
               {else}
-                <td><a href="https://blockchair.com/search?q={$payment->getTransactionId()}" target="_blank">{$payment->getTransactionId()}</a></td>
+                <td><a href="https://blockchair.com/search?q={$payment->getTransactionId()}" target="_blank" rel="noopener noreferrer nofollow">{$payment->getTransactionId()}</a></td>
               {/if}
           </tr>
         {/foreach}


### PR DESCRIPTION
Possible solution for the `Invalid token: direct access to this link may lead to a potential security breach`-issues. The pop-up sometimes appears and sometimes it doesn't and it has been near impossible to debug why. 

One reason I did find is because `PrestaShop` assumes that [`POST`-requests from BTCPay Server are evil](https://github.com/PrestaShop/PrestaShop/blob/ad181f7fb89dea67dfebba779a6440854baa6d5b/src/PrestaShopBundle/EventListener/TokenizedUrlsListener.php#L112) (even though I use a valid token) and I have no way to bypass/resolve it. I did see that routes with `api_` in the name should be skipped, but that triggers something else that logs you out fully, which is not great. 

You can disable the tokens store-wide, but that just feels like a terrible idea, so I've gone back to what we used to do in this plugin, just ask for the API key and display a URL where you can create it with all required permissions. 

This setup is not perfect, but it works: [btcpay v5.2.0.zip](https://github.com/btcpayserver/prestashop-plugin/files/9791794/btcpay.v5.2.0.zip).

----

This will require a documentation change in https://github.com/btcpayserver/btcpayserver-doc/edit/master/docs/PrestaShop.md
