### PR TITLE
Fix stuff breaking on PS8 

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2902,22 +2902,22 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.4.1",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "69568e4293f4fa993f3b0e51c9723e1e17c41379"
+                "reference": "b635f279edd83fc275f822a1188157ffea568ff6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/69568e4293f4fa993f3b0e51c9723e1e17c41379",
-                "reference": "69568e4293f4fa993f3b0e51c9723e1e17c41379",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/b635f279edd83fc275f822a1188157ffea568ff6",
+                "reference": "b635f279edd83fc275f822a1188157ffea568ff6",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-factory": "^1.0",
-                "psr/http-message": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0",
                 "ralouphie/getallheaders": "^3.0"
             },
             "provide": {
@@ -2937,9 +2937,6 @@
                 "bamarni-bin": {
                     "bin-links": true,
                     "forward-command": false
-                },
-                "branch-alias": {
-                    "dev-master": "2.4-dev"
                 }
             },
             "autoload": {
@@ -3001,7 +2998,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.4.1"
+                "source": "https://github.com/guzzle/psr7/tree/2.5.0"
             },
             "funding": [
                 {
@@ -3017,7 +3014,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-28T14:45:39+00:00"
+            "time": "2023-04-17T16:11:26+00:00"
         },
         {
             "name": "incenteev/composer-parameter-handler",
@@ -6175,21 +6172,21 @@
         },
         {
             "name": "psr/http-factory",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-factory.git",
-                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be"
+                "reference": "e616d01114759c4c489f93b099585439f795fe35"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
-                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/e616d01114759c4c489f93b099585439f795fe35",
+                "reference": "e616d01114759c4c489f93b099585439f795fe35",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.0.0",
-                "psr/http-message": "^1.0"
+                "psr/http-message": "^1.0 || ^2.0"
             },
             "type": "library",
             "extra": {
@@ -6209,7 +6206,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interfaces for PSR-7 HTTP message factories",
@@ -6224,31 +6221,31 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-factory/tree/master"
+                "source": "https://github.com/php-fig/http-factory/tree/1.0.2"
             },
-            "time": "2019-04-30T12:38:16+00:00"
+            "time": "2023-04-10T20:10:41+00:00"
         },
         {
             "name": "psr/http-message",
-            "version": "1.0.1",
+            "version": "1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-message.git",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -6277,9 +6274,9 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-message/tree/master"
+                "source": "https://github.com/php-fig/http-message/tree/1.1"
             },
-            "time": "2016-08-06T14:39:51+00:00"
+            "time": "2023-04-04T09:50:52+00:00"
         },
         {
             "name": "psr/link",

--- a/modules/btcpay/composer.lock
+++ b/modules/btcpay/composer.lock
@@ -420,22 +420,22 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.4.1",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "69568e4293f4fa993f3b0e51c9723e1e17c41379"
+                "reference": "b635f279edd83fc275f822a1188157ffea568ff6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/69568e4293f4fa993f3b0e51c9723e1e17c41379",
-                "reference": "69568e4293f4fa993f3b0e51c9723e1e17c41379",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/b635f279edd83fc275f822a1188157ffea568ff6",
+                "reference": "b635f279edd83fc275f822a1188157ffea568ff6",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-factory": "^1.0",
-                "psr/http-message": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0",
                 "ralouphie/getallheaders": "^3.0"
             },
             "provide": {
@@ -455,9 +455,6 @@
                 "bamarni-bin": {
                     "bin-links": true,
                     "forward-command": false
-                },
-                "branch-alias": {
-                    "dev-master": "2.4-dev"
                 }
             },
             "autoload": {
@@ -519,7 +516,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.4.1"
+                "source": "https://github.com/guzzle/psr7/tree/2.5.0"
             },
             "funding": [
                 {
@@ -535,7 +532,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-28T14:45:39+00:00"
+            "time": "2023-04-17T16:11:26+00:00"
         },
         {
             "name": "http-interop/http-factory-guzzle",
@@ -1296,21 +1293,21 @@
         },
         {
             "name": "psr/http-factory",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-factory.git",
-                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be"
+                "reference": "e616d01114759c4c489f93b099585439f795fe35"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
-                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/e616d01114759c4c489f93b099585439f795fe35",
+                "reference": "e616d01114759c4c489f93b099585439f795fe35",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.0.0",
-                "psr/http-message": "^1.0"
+                "psr/http-message": "^1.0 || ^2.0"
             },
             "type": "library",
             "extra": {
@@ -1330,7 +1327,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interfaces for PSR-7 HTTP message factories",
@@ -1345,31 +1342,31 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-factory/tree/master"
+                "source": "https://github.com/php-fig/http-factory/tree/1.0.2"
             },
-            "time": "2019-04-30T12:38:16+00:00"
+            "time": "2023-04-10T20:10:41+00:00"
         },
         {
             "name": "psr/http-message",
-            "version": "1.0.1",
+            "version": "1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-message.git",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -1398,9 +1395,9 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-message/tree/master"
+                "source": "https://github.com/php-fig/http-message/tree/1.1"
             },
-            "time": "2016-08-06T14:39:51+00:00"
+            "time": "2023-04-04T09:50:52+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/modules/btcpay/src/Controller/Admin/Improve/Payment/ConfigureController.php
+++ b/modules/btcpay/src/Controller/Admin/Improve/Payment/ConfigureController.php
@@ -66,7 +66,7 @@ class ConfigureController extends FrameworkBundleAdminController
 		// Create the authorization URL (without redirect)
 		$authorizeUrl = ApiKey::getAuthorizeUrl($this->configuration->get(Constants::CONFIGURATION_BTCPAY_HOST), Constants::BTCPAY_PERMISSIONS, $this->module->name, true, true, null, $this->module->name);
 
-		if (false === $client->isValid()) {
+		if (!$client || false === $client->isValid()) {
 			return $this->render('@Modules/btcpay/views/templates/admin/configure.html.twig', [
 				'form'          => $this->get('prestashop.module.btcpay.form_handler')->getForm()->createView(),
 				'help_link'     => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),

--- a/modules/btcpay/src/Installer/Hooks.php
+++ b/modules/btcpay/src/Installer/Hooks.php
@@ -21,7 +21,6 @@ class Hooks
 		if (!$this->module->registerHook('displayAdminOrderMainBottom')
 			|| !$this->module->registerHook('displayOrderDetail')
 			|| !$this->module->registerHook('displayPaymentEU')
-			|| !$this->module->registerHook('payment')
 			|| !$this->module->registerHook('paymentReturn')
 			|| !$this->module->registerHook('paymentOptions')
 			|| !$this->module->registerHook('actionCartSave')) {

--- a/modules/btcpay/src/Installer/Webhook.php
+++ b/modules/btcpay/src/Installer/Webhook.php
@@ -22,8 +22,9 @@ class Webhook
 	 */
 	public function uninstall(): array
 	{
-		// Remove the current webhook to prevent issues in the future
-		if (false === (Client::createFromConfiguration($this->configuration)->webhook()->removeCurrent())) {
+		// Remove the current webhook to prevent issues in the future.
+		$webhookClient = Client::createFromConfiguration($this->configuration);
+		if ($webhookClient && false === ($webhookClient->webhook()->removeCurrent())) {
 			return [
 				[
 					'key'        => 'Could not remove webhook from the server. Please double check it is actually gone.',

--- a/modules/btcpay/src/Server/Client.php
+++ b/modules/btcpay/src/Server/Client.php
@@ -85,12 +85,18 @@ class Client extends AbstractClient
 		$this->repository    = new LegacyBitcoinPaymentRepository();
 	}
 
-	public static function createFromConfiguration(Configuration $configuration): self
+	public static function createFromConfiguration(Configuration $configuration): ?self
 	{
-		return new self(
-			$configuration->get(Constants::CONFIGURATION_BTCPAY_HOST),
+		if ($configuration->get(Constants::CONFIGURATION_BTCPAY_HOST) &&
 			$configuration->get(Constants::CONFIGURATION_BTCPAY_API_KEY)
-		);
+		) {
+			return new self(
+				$configuration->get(Constants::CONFIGURATION_BTCPAY_HOST),
+				$configuration->get(Constants::CONFIGURATION_BTCPAY_API_KEY)
+			);
+		}
+
+		return null;
 	}
 
 	public function invoice(): InvoiceClient

--- a/modules/btcpay/src/Server/Webhook.php
+++ b/modules/btcpay/src/Server/Webhook.php
@@ -68,7 +68,8 @@ class Webhook extends \BTCPayServer\Client\Webhook
 	public function getCurrent(string $storeId, ?string $webhookId): ?\BTCPayServer\Result\Webhook
 	{
 		try {
-			if (null === $webhookId) {
+			// We need to check for empty here as twig passes a null variable as "" instead of null in configure.html.twig.
+			if (empty($webhookId)) {
 				return null;
 			}
 


### PR DESCRIPTION
Fixes issues with PS 8 so it is usable again, fixes #70 

- Fixed uninstall was not possible after initial upload
- Fixed install * 
- Fixed bug where Twig call would pass an empty string to the getWebhook() call causing an exception and breaking the config form


@BitcoinMitchell 
~~There is still a bug in the installer when you do not yet have the plugin installed and upload it fresh. It will install successfully but when you click on "configure" it will redirect to the dashboard instead of config form. Causing all subsequent clicks in the menu (because the url is prefixed with the module for menu entries).~~

~~The fix is to delete the url and go to module admin again and uninstall the plugin. Then install again and it will work.~~

~~Error description:~~
- ~~when you return to any other page after the faulty first install it says "Access denied"~~
- ~~The shown plugin version after faulty install is 6.0.0 instead of 5.2.1??~~

Edit:
Seems to have been a twig caching issue, could not reproduce the error anymore, so all bugs fixed, ready for merging. :tada: 