### PR TITLE
[GitHub] Use github.ref_name instead of github.ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
-          name: "Release ${{ github.ref }}"
+          name: "Release ${{ github.ref_name }}"
           files: "./build/btcpay.zip"
           fail_on_unmatched_files: true
           generate_release_notes: true


### PR DESCRIPTION
# Description

> `github.ref` : The fully-formed ref of the branch or tag that triggered the workflow run. The ref given is fully-formed, meaning that for branches the format is `refs/heads/<branch_name>`, for pull requests it is `refs/pull/<pr_number>/merge`, and for tags it is `refs/tags/<tag_name>`.

> `github.ref_name`: The short ref name of the branch or tag that triggered the workflow run. This value matches the branch or tag name shown on GitHub.
