### PR TITLE
[Configuration] Ensure ConfigureController works on PS 8.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,7 +123,7 @@ services:
     expose:
       - '8080'
       - '8443'
-    image: 'bitnami/prestashop:8.1.3'
+    image: 'bitnami/prestashop:8.0.4'
     links:
       - mariadb
       - btcpayserver

--- a/modules/btcpay/btcpay.php
+++ b/modules/btcpay/btcpay.php
@@ -52,7 +52,7 @@ class BTCPay extends PaymentModule
 	{
 		$this->name                   = 'btcpay';
 		$this->tab                    = 'payments_gateways';
-		$this->version                = '6.1.4';
+		$this->version                = '6.1.5';
 		$this->author                 = 'BTCPay Server';
 		$this->ps_versions_compliancy = ['min' => Constants::MINIMUM_PS_VERSION, 'max' => _PS_VERSION_];
 		$this->controllers            = ['payment', 'validation', 'webhook'];

--- a/modules/btcpay/src/Controller/Admin/Improve/Payment/ConfigureController.php
+++ b/modules/btcpay/src/Controller/Admin/Improve/Payment/ConfigureController.php
@@ -11,6 +11,7 @@ use BTCPay\Server\Client;
 use BTCPay\Server\Data\ValidateApiKey;
 use BTCPayServer\Client\ApiKey;
 use Exception;
+use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
@@ -291,6 +292,16 @@ class ConfigureController extends FrameworkBundleAdminController
 		$this->addFlash('success', 'BTCPay Server plugin: Your store and server have been linked!');
 
 		return $this->redirectToRoute('admin_btcpay_configure');
+	}
+
+	protected function getConfiguration(): ShopConfigurationInterface
+	{
+		// Fallback in case 8.0 is used // TODO: Remove once we make 8.1.0 the minimum
+		if (\version_compare(\_PS_VERSION_, '8.1.0', '<')) {
+			return $this->configuration;
+		}
+
+		return parent::getConfiguration();
 	}
 
 	/**


### PR DESCRIPTION
# Description

Adds a simple check to ensure we either use the new `$this->getConfiguration()` or the old `$this->configuration`. We can remove this check as soon as we require PS 8.1 as minimum. 

Having said this, we should probably stop supporting PS 8.0 soon, since there are a lot of security issues in those version. In fact, [`Roave/SecurityAdvisories`](https://github.com/Roave/SecurityAdvisories/blob/latest/composer.json#L487) restricts everything below PS 8.1.6.

- Fixes https://github.com/btcpayserver/prestashop-plugin/issues/139

# Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change which improves the codebase)

# How Has This Been Tested?

Start a Docker with the `bitnami/prestashop:8.0.4` image, upload the ZIP, configure the plugin.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings

----

Test zip (v6.1.5): [btcpay.zip](https://github.com/user-attachments/files/16102013/btcpay.zip)