### PR TITLE
Ensure PrestaShop 9 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 Please ensure that you meet the following requirements before installing this plugin.
 
 - You are using PHP 8.0 or higher
-- Your PrestaShop is version 8.0 or higher.
+- Your PrestaShop is version 8.0/9.0 or higher.
 - Your BTCPay Server is version 1.7.0 or higher
 - The PDO, curl, gd, intl, json, and mbstring PHP extensions are available
 - You have a BTCPay Server, either [self-hosted](https://docs.btcpayserver.org/Deployment/) or [hosted by a third party](https://docs.btcpayserver.org/Deployment/ThirdPartyHosting/)
@@ -50,9 +50,9 @@ Please ensure that you meet the following requirements before installing this pl
 - [You've a wallet connected to your store](https://docs.btcpayserver.org/WalletSetup)
 
 ### Tested successfully
-- Prestashop v8.0, v8.0.1, v8.0.4, v8.1.0, v8.1.3 and v8.1.4
-- BTCPay server v1.7.0, v1.7.3.0, v1.12.5, v1.13.0 and v1.13.5
-  - BTCPay server v2 should be supported as of module version v6.3.0.
+- Prestashop v8.0, v8.0.1, v8.0.4, v8.1.0, v8.1.3, v8.1.4, v8.2.1, v9.0.0
+- BTCPay server v1.7.0, v1.7.3.0, v1.12.5, v1.13.0, v1.13.5, v2.1.5, v2.2.1 
+  - BTCPay server v2 is supported as of module version v6.3.0.
 
 ### Multistore
 

--- a/modules/btcpay/btcpay.php
+++ b/modules/btcpay/btcpay.php
@@ -240,8 +240,12 @@ class BTCPay extends PaymentModule
 
 		try {
 			// Get the invoice and its payments
-			$invoice        = $client->invoice()->getInvoice($storeID, $invoiceId);
-			$paymentMethods = $client->invoice()->getPaymentMethods($storeID, $invoiceId);
+			$invoice = $client->invoice()->getInvoice($storeID, $invoiceId);
+
+			// Filter out methods without payments
+			$paymentMethods = array_filter($client->invoice()->getPaymentMethods($storeID, $invoiceId), static function ($method) {
+				return !empty($method->getPayments());
+			});
 
 			// Has any payment been received
 			$paymentReceived = array_reduce($paymentMethods, static function ($carry, $method) {

--- a/modules/btcpay/btcpay.php
+++ b/modules/btcpay/btcpay.php
@@ -52,7 +52,7 @@ class BTCPay extends PaymentModule
 	{
 		$this->name                   = 'btcpay';
 		$this->tab                    = 'payments_gateways';
-		$this->version                = '6.3.0';
+		$this->version                = '6.3.1';
 		$this->author                 = 'BTCPay Server';
 		$this->ps_versions_compliancy = ['min' => Constants::MINIMUM_PS_VERSION, 'max' => _PS_VERSION_];
 		$this->controllers            = ['payment', 'validation', 'webhook'];

--- a/modules/btcpay/controllers/front/payment.php
+++ b/modules/btcpay/controllers/front/payment.php
@@ -60,7 +60,9 @@ class BTCPayPaymentModuleFrontController extends ModuleFrontController
 
 			$this->warning[] = $this->context->getTranslator()->trans('We could not create a payment request via BTCPay Server. Please try again or contact us.', [], 'Modules.Btcpay.Front');
 			$this->redirectWithNotifications($this->context->link->getPageLink('cart', $this->ssl));
-		} catch (\Throwable) {
+		} catch (\Throwable $throwable) {
+			PrestaShopLogger::addLog(\sprintf('[ERROR] An error occurred during payment creation: %s', $throwable), PrestaShopLogger::LOG_SEVERITY_LEVEL_ERROR, $throwable->getCode());
+
 			$this->warning[] = $this->context->getTranslator()->trans('We are having issues with our BTCPay Server backend. Please try again or contact us.', [], 'Modules.Btcpay.Front');
 			$this->redirectWithNotifications($this->context->link->getPageLink('cart', $this->ssl));
 		}

--- a/modules/btcpay/controllers/front/payment.php
+++ b/modules/btcpay/controllers/front/payment.php
@@ -53,7 +53,7 @@ class BTCPayPaymentModuleFrontController extends ModuleFrontController
 
 		try {
 			if (null !== ($redirect = $this->factory->createPaymentRequest($this->context->customer, $this->context->cart))) {
-				Tools::redirectLink($redirect);
+				Tools::redirect($redirect);
 
 				return;
 			}

--- a/modules/btcpay/src/Controller/Admin/Improve/Payment/ConfigureController.php
+++ b/modules/btcpay/src/Controller/Admin/Improve/Payment/ConfigureController.php
@@ -62,7 +62,10 @@ class ConfigureController extends FrameworkBundleAdminController
 
 	public function __construct(BTCPay $module, ValidatorInterface $validator, FormHandlerInterface $serverFormHandler, FormHandlerInterface $generalFormHandler)
 	{
-		parent::__construct();
+		// Fallback in case 8.0 is used // TODO: Remove once we make 9.0 the minimum
+		if (\version_compare(\_PS_VERSION_, '8.1.0', '<')) {
+			parent::__construct();
+		}
 
 		$this->module             = $module;
 		$this->validator          = $validator;
@@ -296,7 +299,7 @@ class ConfigureController extends FrameworkBundleAdminController
 
 	protected function getConfiguration(): ShopConfigurationInterface
 	{
-		// Fallback in case 8.0 is used // TODO: Remove once we make 8.1.0 the minimum
+		// Fallback in case 8.0 is used // TODO: Remove once we make 9.0 the minimum
 		if (\version_compare(\_PS_VERSION_, '8.1.0', '<')) {
 			return $this->configuration;
 		}

--- a/modules/btcpay/views/templates/admin/configure.html.twig
+++ b/modules/btcpay/views/templates/admin/configure.html.twig
@@ -135,7 +135,6 @@
         <div class="card-deck">
           <div class="card">
             <h3 class="card-header">
-              <i class="material-icons">store</i>
               {{ 'Store Information'|trans({}, 'Admin.Actions') }}
             </h3>
 
@@ -164,7 +163,6 @@
 
           <div class="card">
             <h3 class="card-header">
-              <i class="material-icons">info_outline</i>
               {{ 'Server Information'|trans({}, 'Admin.Actions') }}
             </h3>
 
@@ -176,7 +174,7 @@
                 {% set webhook = client.webhook().getCurrent(storeId, webhookId) %}
                 <dt><span class="text-muted mb-0"><strong>{{ 'Webhook'|trans({}, 'Modules.Btcpay.Admin') }}</strong></span></dt>
                 {% if webhook is not null and webhook.enabled is defined and webhook.enabled %}
-                  <dd><span class="text-success px-1"><i class="material-icons">checkmark</i></span></dd>
+                  <dd><span class="text-success px-1">✓</span></dd>
                 {% elseif webhook is not null and webhook.enabled is defined and not webhook.enabled %}
                   <dd><span class="text-warning px-1">Webhook has been disabled, re-enable it again your store</span></dd>
                 {% else %}

--- a/modules/btcpay/views/templates/admin/invoice_block.tpl
+++ b/modules/btcpay/views/templates/admin/invoice_block.tpl
@@ -49,7 +49,7 @@
         <div class="nav nav-tabs" id="nav-tab" role="tablist">
         {foreach $paymentMethods as $paymentMethod}
           {if not empty($paymentMethod->getPayments())}
-            {assign currencyCode "_"|explode:$paymentMethod.paymentMethod|current}
+            {assign currencyCode "_"|explode:($paymentMethod.paymentMethod|default:$paymentMethod.currency)|current}
             <a class="nav-item nav-link{if $paymentMethod@first} active{/if}" id="nav-{$currencyCode|strtolower|escape:'htmlall':'UTF-8'}-tab" data-toggle="tab" href="#nav-{$currencyCode|strtolower|escape:'htmlall':'UTF-8'}" role="tab" aria-controls="nav-{$currencyCode|strtolower|escape:'htmlall':'UTF-8'}" aria-selected="true">
               <strong>{$currencyCode|escape:'htmlall':'UTF-8'}</strong>
             </a>
@@ -60,48 +60,48 @@
       <div class="tab-content" id="nav-tabContent">
       {foreach $paymentMethods as $paymentMethod}
         {if not empty($paymentMethod->getPayments())}
-              {assign currencyCode "_"|explode:$paymentMethod.paymentMethod|current}
-              <div class="tab-pane fade{if $paymentMethod@first} show active{/if}" id="nav-{$currencyCode|strtolower|escape:'htmlall':'UTF-8'}" role="tabpanel" aria-labelledby="nav-{$currencyCode|strtolower|escape:'htmlall':'UTF-8'}-tab">
-                <table id="{$currencyCode|escape:'htmlall':'UTF-8'}-details" class="table table-bordered my-2">
-                  <thead>
-                  <tr>
-                    <th class="table-head-rate">{l s='Rate' d='Modules.Btcpay.Global'}</th>
-                    <th class="table-head-cart-amount">{l s='Invoice amount' d='Modules.Btcpay.Global'}</th>
-                    <th class="table-head-paid-amount">{l s='Total amount paid in %s' sprintf=[$currencyCode|escape:'htmlall':'UTF-8'] d='Modules.Btcpay.Global'}</th>
-                  </tr>
-                  </thead>
-                  <tbody>
-                  <tr>
-                    <td>{$storeCurrency|escape:'htmlall':'UTF-8'} {$paymentMethod.rate|escape:'htmlall':'UTF-8'}</td>
-                    <td>{$paymentMethod.amount|escape:'htmlall':'UTF-8'} {$paymentMethod.paymentMethod|escape:'htmlall':'UTF-8'}</td>
-                    <td>{$paymentMethod.paymentMethodPaid|escape:'htmlall':'UTF-8'} {$paymentMethod.paymentMethod|escape:'htmlall':'UTF-8'}</td>
-                  </tr>
-                  </tbody>
-                </table>
-                <table id="{$currencyCode|escape:'htmlall':'UTF-8'}-payments" class="table table-bordered my-2">
-                  <thead>
-                  <tr>
-                    <th class="table-head-date">{l s='Date' d='Modules.Btcpay.Global'}</th>
-                    <th class="table-head-amount">{l s='Amount' d='Modules.Btcpay.Global'}</th>
-                    <th class="table-head-destination">{l s='Transaction' d='Modules.Btcpay.Global'}</th>
-                  </tr>
-                  </thead>
-                  <tbody>
-                  {foreach $paymentMethod->getPayments() as $payment}
-                    <tr>
-                      <td>{$payment->getReceivedTimestamp()|date_format:"%Y-%m-%d %T"}</td>
-                      <td>{$payment.value|escape:'htmlall':'UTF-8'} {$currencyCode|escape:'htmlall':'UTF-8'}</td>
-                        {if $currencyCode == 'BTC'}
-                          <td><a href="https://mempool.space/tx/{$payment->getTransactionId()|escape:'htmlall':'UTF-8'}" target="_blank" rel="noopener noreferrer nofollow">{$payment->getTransactionId()|escape:'htmlall':'UTF-8'}</a></td>
-                        {else}
-                          <td><a href="https://blockchair.com/search?q={$payment->getTransactionId()|escape:'htmlall':'UTF-8'}" target="_blank" rel="noopener noreferrer nofollow">{$payment->getTransactionId()|escape:'htmlall':'UTF-8'}</a></td>
-                        {/if}
-                    </tr>
-                  {/foreach}
-                  </tbody>
-                </table>
-              </div>
-            {/if}
+          {assign currencyCode "_"|explode:($paymentMethod.paymentMethod|default:$paymentMethod.currency)|current}
+          <div class="tab-pane fade{if $paymentMethod@first} show active{/if}" id="nav-{$currencyCode|strtolower|escape:'htmlall':'UTF-8'}" role="tabpanel" aria-labelledby="nav-{$currencyCode|strtolower|escape:'htmlall':'UTF-8'}-tab">
+            <table id="{$currencyCode|escape:'htmlall':'UTF-8'}-details" class="table table-bordered my-2">
+              <thead>
+              <tr>
+                <th class="table-head-rate">{l s='Rate' d='Modules.Btcpay.Global'}</th>
+                <th class="table-head-cart-amount">{l s='Invoice amount' d='Modules.Btcpay.Global'}</th>
+                <th class="table-head-paid-amount">{l s='Total amount paid in %s' sprintf=[$currencyCode|escape:'htmlall':'UTF-8'] d='Modules.Btcpay.Global'}</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td>{$storeCurrency|escape:'htmlall':'UTF-8'} {$paymentMethod.rate|escape:'htmlall':'UTF-8'}</td>
+                <td>{$paymentMethod.amount|escape:'htmlall':'UTF-8'} {$paymentMethod.paymentMethod|escape:'htmlall':'UTF-8'}</td>
+                <td>{$paymentMethod.paymentMethodPaid|escape:'htmlall':'UTF-8'} {$paymentMethod.paymentMethod|escape:'htmlall':'UTF-8'}</td>
+              </tr>
+              </tbody>
+            </table>
+            <table id="{$currencyCode|escape:'htmlall':'UTF-8'}-payments" class="table table-bordered my-2">
+              <thead>
+              <tr>
+                <th class="table-head-date">{l s='Date' d='Modules.Btcpay.Global'}</th>
+                <th class="table-head-amount">{l s='Amount' d='Modules.Btcpay.Global'}</th>
+                <th class="table-head-destination">{l s='Transaction' d='Modules.Btcpay.Global'}</th>
+              </tr>
+              </thead>
+              <tbody>
+              {foreach $paymentMethod->getPayments() as $payment}
+                <tr>
+                  <td>{$payment->getReceivedTimestamp()|date_format:"%Y-%m-%d %T"}</td>
+                  <td>{$payment.value|escape:'htmlall':'UTF-8'} {$currencyCode|escape:'htmlall':'UTF-8'}</td>
+                    {if $currencyCode == 'BTC'}
+                      <td><a href="https://mempool.space/tx/{$payment->getTransactionId()|escape:'htmlall':'UTF-8'}" target="_blank" rel="noopener noreferrer nofollow">{$payment->getTransactionId()|escape:'htmlall':'UTF-8'}</a></td>
+                    {else}
+                      <td><a href="https://blockchair.com/search?q={$payment->getTransactionId()|escape:'htmlall':'UTF-8'}" target="_blank" rel="noopener noreferrer nofollow">{$payment->getTransactionId()|escape:'htmlall':'UTF-8'}</a></td>
+                    {/if}
+                </tr>
+              {/foreach}
+              </tbody>
+            </table>
+          </div>
+        {/if}
       {/foreach}
       </div>
     {/if}


### PR DESCRIPTION
# Description

Since PrestaShop has released their latest major version, it is time that we upgrade our module as well.

# Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change which improves the codebase)

# How Has This Been Tested?

I ran PrestaShop 9 locally (using BTCPay Server Testnet) and kept fixing issues until it worked. I then tested the module on my shop that still runs PrestaShop 8. All good.

**Test Configuration**:
* BTCPay Server version: v2.1.5 / v2.2.1+790616d2a
* PrestaShop version: 9.0.0 / 8.2.1
* PHP version: 8.4.12 / 8.2.27

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings

---

[btcpay v6.3.1.zip](https://github.com/user-attachments/files/22372530/btcpay.v6.3.1.zip)
