### PR TITLE
fix: Allow BTCPay webhooks during PrestaShop maintenance mode

### DIFF
--- a/modules/btcpay/controllers/front/webhook.php
+++ b/modules/btcpay/controllers/front/webhook.php
@@ -104,4 +104,11 @@ class BTCPayWebhookModuleFrontController extends \ModuleFrontController
 		echo 'OK';
 		exit;
 	}
+
+	/**
+	 * Allow BTCPay IPNs while the shop is in maintenance mode.
+	 */
+	protected function displayMaintenancePage(): void
+	{
+	}
 }


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

- Fixes #181 

# Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change which improves the codebase)

# How Has This Been Tested?

Not yet tested, but I'm 99% sure it will work, since a lot of payment modules do (include PS itself):
- https://github.com/begateway/prestashop-payment-module/blob/master/begateway/controllers/front/webhook.php#L40
- https://github.com/mollie/PrestaShop/blob/master/controllers/front/webhook.php#L49
- https://github.com/PrestaShopCorp/ps_checkout/blob/main/ps9/controllers/front/DispatchWebHook.php#L155

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
