### PR TITLE
Implement discussion features + stop fallthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ If you have trouble using BTCPay Server, consider joining [communities listed on
 
 To get up and running with our plugin quickly, see the [PrestaShop Guide on our documentation website](https://docs.btcpayserver.org/PrestaShop/).
 
+## 📧 Merchant alerts (logs by email)
+
+Severe module issues (configuration auto-reset, webhook/invoice processing failures, etc.) are written to the PrestaShop logs at **Error** severity. PrestaShop can email you those entries; the module does not send its own alert mail.
+
+In the back office, open **Advanced Parameters -> Logs** and ensure:
+
+1. **Minimum severity level for logs by email** is set to **Error** (or Major).
+2. **Send emails to** includes an address you monitor (often the shop contact email).
+3. Shop mail itself works (**Advanced Parameters -> E-mail**; send a test message).
+
+With that enabled, open the log entry from the alert mail under **Advanced Parameters -> Logs** for the full message. Invalid webhook signature probes are logged as **Warning** so they do not flood your inbox.
+
 ## 🧑‍💻 Versioning
 
 We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [releases within this repository](https://github.com/btcpayserver/prestashop-plugin/releases).

--- a/modules/btcpay/btcpay.php
+++ b/modules/btcpay/btcpay.php
@@ -497,7 +497,11 @@ class BTCPay extends PaymentModule
 			}
 		} catch (BTCPayException $exception) {
 			// Log the exception
-			PrestaShopLogger::addLog(\sprintf('[WARNING] BTCPay Server configuration is no longer valid, resetting host and API key. Error: %s', $exception->getMessage()), \PrestaShopLogger::LOG_SEVERITY_LEVEL_WARNING, $exception->getCode());
+			PrestaShopLogger::addLog(
+				\sprintf('[ERROR] BTCPay Server configuration is no longer valid, resetting host and API key. Error: %s', $exception->getMessage()),
+				\PrestaShopLogger::LOG_SEVERITY_LEVEL_ERROR,
+				$exception->getCode()
+			);
 
 			// Show a warning
 			$this->warning = $this->trans('Your BTCPay Server configuration is no longer valid, please setup module again.', [], 'Modules.Btcpay.Admin');

--- a/modules/btcpay/controllers/front/webhook.php
+++ b/modules/btcpay/controllers/front/webhook.php
@@ -69,9 +69,10 @@ class BTCPayWebhookModuleFrontController extends \ModuleFrontController
 	 */
 	public function postProcess(): void
 	{
+		// Create the request
 		$request = Request::createFromGlobals();
 
-		// BTCPay webhooks are POST-only; reject probes and misconfigured clients early
+		// BTCPay webhooks are POST-only, reject anything else
 		if (!$request->isMethod('POST')) {
 			header('HTTP/1.1 405 Method Not Allowed');
 			exit;
@@ -85,21 +86,41 @@ class BTCPayWebhookModuleFrontController extends \ModuleFrontController
 			exit;
 		}
 
-		// Ensure the client is ready for use, if not, just return
-		if (null === $this->client || false === $this->client->isValid()) {
-			header('HTTP/1.1 400 Bad Request');
-			exit;
-		}
+		// Grab the body of the request
+		$body = $request->getContent();
 
-		// Ensure our webhook is actually valid
+		// Validate the HMAC first, log the error and return a 401 error if the signature does not match
 		if (false === $this->client->webhook()->isIncomingWebhookRequestValid($request->getContent(), $signature, $secret)) {
-			$error = 'Invalid BTCPay Server payment notification message received - signature did not match.';
-			\PrestaShopLogger::addLog($error, \PrestaShopLogger::LOG_SEVERITY_LEVEL_ERROR);
+			\PrestaShopLogger::addLog(
+				'Invalid BTCPay Server payment notification message received - signature did not match.',
+				\PrestaShopLogger::LOG_SEVERITY_LEVEL_WARNING
+			);
 			header('HTTP/1.1 401 Unauthorized');
 			exit;
 		}
 
-		$this->handler->process($request);
+		// Ensure our webhook is actually valid
+		if (null === $this->client || false === $this->client->isValid()) {
+			\PrestaShopLogger::addLog(
+				'[ERROR] A signed BTCPay webhook was received but the module could not create a valid BTCPay Server client. Check that the store is still linked and the API key is valid.',
+				\PrestaShopLogger::LOG_SEVERITY_LEVEL_ERROR
+			);
+			header('HTTP/1.1 400 Bad Request');
+			exit;
+		}
+
+		// Try to process the webhook
+		try {
+			$this->handler->process($request);
+		} catch (\Throwable $throwable) {
+			\PrestaShopLogger::addLog(
+				\sprintf('[ERROR] Webhook processing failed: %s', $throwable->getMessage()),
+				\PrestaShopLogger::LOG_SEVERITY_LEVEL_ERROR,
+				$throwable->getCode()
+			);
+			header('HTTP/1.1 500 Internal Server Error');
+			exit;
+		}
 
 		echo 'OK';
 		exit;

--- a/modules/btcpay/src/Controller/Admin/Improve/Payment/ConfigureController.php
+++ b/modules/btcpay/src/Controller/Admin/Improve/Payment/ConfigureController.php
@@ -9,6 +9,7 @@ use BTCPay\Form\Data\Server;
 use BTCPay\Github\Versioning;
 use BTCPay\Server\Client;
 use BTCPay\Server\Data\ValidateApiKey;
+use BTCPay\Server\RateFallbackStatus;
 use BTCPayServer\Client\ApiKey;
 use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
@@ -433,17 +434,25 @@ class ConfigureController extends FrameworkBundleAdminController
 
 	private function getResponse(Request $request, FormInterface $serverForm, FormInterface $generalForm, string $authorizeUrl, ?Client $client): Response
 	{
+		$storeId            = $this->getConfiguration()->get(Constants::CONFIGURATION_BTCPAY_STORE_ID);
+		$rateFallbackStatus = null;
+
+		if (null !== $client && $client->isValid() && !empty($storeId)) {
+			$rateFallbackStatus = RateFallbackStatus::resolve($client->storeRate(), (string) $storeId);
+		}
+
 		return $this->render('@Modules/btcpay/views/templates/admin/configure.html.twig', [
-			'server_form'   => $serverForm->createView(),
-			'general_form'  => $generalForm->createView(),
-			'help_link'     => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
-			'storeId'       => $this->getConfiguration()->get(Constants::CONFIGURATION_BTCPAY_STORE_ID),
-			'webhookId'     => $this->getConfiguration()->get(Constants::CONFIGURATION_BTCPAY_WEBHOOK_ID),
-			'latestVersion' => $this->versioning->latest(),
-			'moduleVersion' => $this->module->version,
-			'authorizeUrl'  => $authorizeUrl,
-			'client'        => $client,
-			'enableSidebar' => true,
+			'server_form'        => $serverForm->createView(),
+			'general_form'       => $generalForm->createView(),
+			'help_link'          => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
+			'storeId'            => $storeId,
+			'webhookId'          => $this->getConfiguration()->get(Constants::CONFIGURATION_BTCPAY_WEBHOOK_ID),
+			'latestVersion'      => $this->versioning->latest(),
+			'moduleVersion'      => $this->module->version,
+			'authorizeUrl'       => $authorizeUrl,
+			'client'             => $client,
+			'rateFallbackStatus' => $rateFallbackStatus,
+			'enableSidebar'      => true,
 		]);
 	}
 }

--- a/modules/btcpay/src/Invoice/Processor.php
+++ b/modules/btcpay/src/Invoice/Processor.php
@@ -53,9 +53,14 @@ class Processor
 	{
 		// Get the order
 		$order = new \Order($bitcoinPayment->getOrderId());
+		if (false === \Validate::isLoadedObject($order)) {
+			\PrestaShopLogger::addLog(\sprintf("[ERROR] Could not load order '%s' for settled invoice", $bitcoinPayment->getOrderId()), \PrestaShopLogger::LOG_SEVERITY_LEVEL_ERROR, null, 'BitcoinPayment', $bitcoinPayment->getId());
+
+			return;
+		}
 
 		// Set the default status to be the current status
-		$orderStatus = $order->current_state;
+		$orderStatus = (string) $order->current_state;
 
 		// Get the store ID
 		$storeID = $this->configuration->get(Constants::CONFIGURATION_BTCPAY_STORE_ID);
@@ -100,9 +105,14 @@ class Processor
 	{
 		// Get the order
 		$order = new \Order($bitcoinPayment->getOrderId());
+		if (false === \Validate::isLoadedObject($order)) {
+			\PrestaShopLogger::addLog(\sprintf("[ERROR] Could not load order '%s' for failed invoice", $bitcoinPayment->getOrderId()), \PrestaShopLogger::LOG_SEVERITY_LEVEL_ERROR, null, 'BitcoinPayment', $bitcoinPayment->getId());
+
+			return;
+		}
 
 		// Set the default status to be the current status
-		$orderStatus = $order->current_state;
+		$orderStatus = (string) $order->current_state;
 
 		// Get the store ID
 		$storeID = $this->configuration->get(Constants::CONFIGURATION_BTCPAY_STORE_ID);

--- a/modules/btcpay/src/Server/Client.php
+++ b/modules/btcpay/src/Server/Client.php
@@ -51,6 +51,11 @@ class Client extends AbstractClient
 	private $webhook;
 
 	/**
+	 * @var StoreRate
+	 */
+	private $storeRate;
+
+	/**
 	 * @var Configuration
 	 */
 	private $configuration;
@@ -61,12 +66,13 @@ class Client extends AbstractClient
 
 		parent::__construct($baseUrl, $apiKey, $httpClient);
 
-		$this->apiKey   = new ApiKeyClient($baseUrl, $apiKey, $httpClient);
-		$this->invoice  = new InvoiceClient($baseUrl, $apiKey, $httpClient);
-		$this->server   = new ServerClient($baseUrl, $apiKey, $httpClient);
-		$this->store    = new StoreClient($baseUrl, $apiKey, $httpClient);
-		$this->payment  = new StorePaymentMethod($baseUrl, $apiKey, $httpClient);
-		$this->webhook  = new Webhook($baseUrl, $apiKey, $httpClient);
+		$this->apiKey    = new ApiKeyClient($baseUrl, $apiKey, $httpClient);
+		$this->invoice   = new InvoiceClient($baseUrl, $apiKey, $httpClient);
+		$this->server    = new ServerClient($baseUrl, $apiKey, $httpClient);
+		$this->store     = new StoreClient($baseUrl, $apiKey, $httpClient);
+		$this->payment   = new StorePaymentMethod($baseUrl, $apiKey, $httpClient);
+		$this->webhook   = new Webhook($baseUrl, $apiKey, $httpClient);
+		$this->storeRate = new StoreRate($baseUrl, $apiKey, $httpClient);
 
 		$this->configuration = new Configuration();
 	}
@@ -117,6 +123,11 @@ class Client extends AbstractClient
 	public function webhook(): Webhook
 	{
 		return $this->webhook;
+	}
+
+	public function storeRate(): StoreRate
+	{
+		return $this->storeRate;
 	}
 
 	public function isValid(): bool

--- a/modules/btcpay/src/Server/RateFallbackStatus.php
+++ b/modules/btcpay/src/Server/RateFallbackStatus.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace BTCPay\Server;
+
+use BTCPayServer\Exception\RequestException;
+use BTCPayServer\Result\StoreRateSettings;
+
+if (!\defined('_PS_VERSION_')) {
+	exit;
+}
+
+/**
+ * Maps greenfield rate-configuration responses to a simple UI/notify status.
+ */
+class RateFallbackStatus
+{
+	public const CONFIGURED = 'configured';
+	public const MISSING    = 'missing';
+	public const UNKNOWN    = 'unknown';
+
+	/**
+	 * @var string
+	 */
+	private $status;
+
+	/**
+	 * @var string|null
+	 */
+	private $source;
+
+	private function __construct(string $status, ?string $source = null)
+	{
+		$this->status = $status;
+		$this->source = $source;
+	}
+
+	public static function configured(?string $source = null): self
+	{
+		return new self(self::CONFIGURED, $source);
+	}
+
+	public static function missing(): self
+	{
+		return new self(self::MISSING);
+	}
+
+	public static function unknown(): self
+	{
+		return new self(self::UNKNOWN);
+	}
+
+	public static function fromSettings(StoreRateSettings $settings): self
+	{
+		$data           = $settings->getData();
+		$preferredSource = isset($data['preferredSource']) ? (string) $data['preferredSource'] : '';
+		$isCustomScript  = !empty($data['isCustomScript']);
+
+		if ('' !== $preferredSource || $isCustomScript) {
+			return self::configured('' !== $preferredSource ? $preferredSource : 'custom script');
+		}
+
+		return self::missing();
+	}
+
+	public static function fromThrowable(\Throwable $throwable): self
+	{
+		if ($throwable instanceof RequestException && 404 === $throwable->getCode()) {
+			return self::missing();
+		}
+
+		return self::unknown();
+	}
+
+	/**
+	 * Resolve fallback status for a store using the greenfield StoreRate client.
+	 */
+	public static function resolve(StoreRate $storeRate, string $storeId): self
+	{
+		try {
+			return self::fromSettings($storeRate->getSettingsBySource($storeId, StoreRate::SOURCE_FALLBACK));
+		} catch (\Throwable $throwable) {
+			return self::fromThrowable($throwable);
+		}
+	}
+
+	public function getStatus(): string
+	{
+		return $this->status;
+	}
+
+	public function getSource(): ?string
+	{
+		return $this->source;
+	}
+
+	public function isConfigured(): bool
+	{
+		return self::CONFIGURED === $this->status;
+	}
+
+	public function isMissing(): bool
+	{
+		return self::MISSING === $this->status;
+	}
+}

--- a/modules/btcpay/src/Server/StoreRate.php
+++ b/modules/btcpay/src/Server/StoreRate.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace BTCPay\Server;
+
+use BTCPayServer\Http\ClientInterface;
+use BTCPayServer\Result\StoreRateSettings;
+
+if (!\defined('_PS_VERSION_')) {
+	exit;
+}
+
+class StoreRate extends \BTCPayServer\Client\StoreRate
+{
+	public const SOURCE_PRIMARY  = 'primary';
+	public const SOURCE_FALLBACK = 'fallback';
+
+	public function __construct(string $baseUrl, string $apiKey, ?ClientInterface $client = null)
+	{
+		parent::__construct($baseUrl, $apiKey, $client);
+	}
+
+	/**
+	 * @throws \JsonException
+	 */
+	public function getSettingsBySource(string $storeId, string $rateSource): StoreRateSettings
+	{
+		$url      = $this->getApiUrl() . 'stores/' . \urlencode($storeId) . '/rates/configuration/' . \urlencode($rateSource);
+		$headers  = $this->getRequestHeaders();
+		$method   = 'GET';
+		$response = $this->getHttpClient()->request($method, $url, $headers);
+
+		if (200 === $response->getStatus()) {
+			return new StoreRateSettings(\json_decode($response->getBody(), true, 512, \JSON_THROW_ON_ERROR));
+		}
+
+		throw $this->getExceptionByStatusCode($method, $url, $response);
+	}
+}

--- a/modules/btcpay/src/Server/WebhookHandler.php
+++ b/modules/btcpay/src/Server/WebhookHandler.php
@@ -44,8 +44,10 @@ class WebhookHandler
 	 */
 	public function process(Request $request): void
 	{
-		$data = \json_decode($request->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-		if (false === $data || null === $data) {
+		$data = \json_decode($request->getContent(), true);
+		if (!\is_array($data)) {
+			\PrestaShopLogger::addLog('[WARNING] Ignoring webhook with invalid JSON', \PrestaShopLogger::LOG_SEVERITY_LEVEL_WARNING);
+
 			return;
 		}
 

--- a/modules/btcpay/src/Server/WebhookHandler.php
+++ b/modules/btcpay/src/Server/WebhookHandler.php
@@ -225,6 +225,8 @@ class WebhookHandler
 		// Check if protection is disabled, if so, just process the failure
 		if (false === $this->configuration->get(Constants::CONFIGURATION_PROTECT_ORDERS, true)) {
 			$this->processor->invoiceFailed($bitcoinPayment);
+
+			return;
 		}
 
 		// Otherwise, will need to check the order so fetch it

--- a/modules/btcpay/views/templates/admin/configure.html.twig
+++ b/modules/btcpay/views/templates/admin/configure.html.twig
@@ -18,6 +18,19 @@
   </div>
   {% endif %}
 
+  {% if storeAvailable and rateFallbackStatus is defined and rateFallbackStatus is not null and rateFallbackStatus.status == 'missing' %}
+  <div class="row ps17">
+    <div class="col-12 col-spx-12 col-lg-10 col-md-10 offset-md-1 offset-lg-1">
+      <div class="alert alert-warning alert-dismissible fade show" role="alert">
+        <p>{{ 'Your BTCPay Server store has no fallback rate provider. If the primary rate source fails, invoices cannot be created. <a href="%url%" class="alert-link" target="_blank" rel="noopener noreferrer nofollow">Configure a fallback rate in BTCPay Server</a>.'|trans({'%url%': client.baseUrl ~ '/stores/' ~ storeId ~ '/rates'}, 'Modules.Btcpay.Admin')|raw }}</p>
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+
   <div class="row ps17">
     <div class="col-12 col-spx-12 col-lg-10 col-md-10 offset-md-1 offset-lg-1">
       <div class="card">
@@ -155,6 +168,17 @@
 
                   <dt><span class="text-muted mb-0"><strong>{{ 'Default currency'|trans({}, 'Modules.Btcpay.Admin') }}</strong></span></dt>
                   <dd><span class="px-1">{% if storeInfo.defaultCurrency is empty %}{{ 'None'|trans({}, 'Modules.BtcPay.Global') }}{% else %}{{ storeInfo.defaultCurrency }}{% endif %}</span>
+                  </dd>
+
+                  <dt><span class="text-muted mb-0"><strong>{{ 'Fallback rate provider'|trans({}, 'Modules.Btcpay.Admin') }}</strong></span></dt>
+                  <dd>
+                    {% if rateFallbackStatus is defined and rateFallbackStatus is not null and rateFallbackStatus.status == 'configured' %}
+                      <span class="text-success px-1">{{ 'Yes'|trans({}, 'Admin.Global') }}{% if rateFallbackStatus.source %} ({{ rateFallbackStatus.source }}){% endif %}</span>
+                    {% elseif rateFallbackStatus is defined and rateFallbackStatus is not null and rateFallbackStatus.status == 'missing' %}
+                      <span class="text-warning px-1">{{ 'No'|trans({}, 'Admin.Global') }} ⚠️ — <a href="{{ client.baseUrl }}/stores/{{ storeId }}/rates" target="_blank" rel="noopener noreferrer nofollow">{{ 'Configure in BTCPay Server'|trans({}, 'Modules.Btcpay.Admin') }}</a></span>
+                    {% else %}
+                      <span class="text-muted px-1">{{ 'Unable to check (requires BTCPay Server 2.1.2+)'|trans({}, 'Modules.Btcpay.Admin') }}</span>
+                    {% endif %}
                   </dd>
                 </dl>
               </div>


### PR DESCRIPTION
# Description

Shows the BTCPay fallback rate provider status on configure page, including a warning if none is set. I've improved the log levels and added a section to the README about making sure to enable `Logs by email`. 

Also contains a quick fix to prevent a fall through in the `WebhookHandler`.

In my store 

- Fixes #222
- Fixes #221
- Fixes #187 

# Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change which improves the codebase)

# How Has This Been Tested?

Ran it on my local development setup (which I will commit in the next PR).

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
